### PR TITLE
wp_unslash fix

### DIFF
--- a/components/header/masthead.php
+++ b/components/header/masthead.php
@@ -26,7 +26,7 @@ if ( ! empty( $memberlite_banner_show ) ) {
 					
 					<?php
 					if ( is_page_template( 'templates/interstitial.php' ) ) {
-						$referrer = isset( $_GET['redirect_to'] ) ? esc_url_raw( $_GET['redirect_to'] ) : null;
+						$referrer = isset( $_GET['redirect_to'] ) ? esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) : null;
 						?>
 						<a class="btn" href="<?php echo esc_url( $referrer ); ?>"><?php _e( 'No Thanks &raquo;', 'memberlite' ); ?></a>
 					<?php } ?>


### PR DESCRIPTION
wp_unslash the redirect_to parameter as per theme review.