### PR TITLE
Padding around Nav Widget Menu removed

### DIFF
--- a/style.css
+++ b/style.css
@@ -1120,7 +1120,6 @@ a:active {
 #mobile-navigation .search-form {
 	padding: 1rem;
 }
-#mobile-navigation .widget.widget_nav_menu,
 #mobile-navigation .widget.widget_search {
 	padding: 0;
 }


### PR DESCRIPTION
Keeping this results in the nav menu creeping against the container on mobile view.

Related to #136