### PR TITLE
Swapping logo area html tag for p on interior pages for SEO and acces…

### DIFF
--- a/header.php
+++ b/header.php
@@ -67,11 +67,23 @@
 
 				<?php memberlite_the_custom_logo(); ?>
 
-				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+				<?php
+					/**
+					 * Accessible and search-optimized page title HTML markup.
+					 * Use h1 if this is the front page of the site and
+					 * p if on an interior page.
+					 */
+					if ( is_front_page() ) {
+						$site_title_html_tag = 'h1';
+					} else {
+						$site_title_html_tag = 'p';
+					}
+				?>
+				<<?php echo esc_attr( $site_title_html_tag ); ?> class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></<?php echo esc_attr( $site_title_html_tag ); ?>>
 
-				<span class="site-description"><?php bloginfo( 'description' ); ?></span>
+				<p class="site-description"><?php bloginfo( 'description' ); ?></p>
 
-			</div><!-- .column4 -->
+			</div><!-- .site-branding -->
 
 			<?php if ( ! empty( $show_header_right ) ) { ?>
 				<div class="medium-<?php echo esc_attr( memberlite_getColumnsRatio( 'header-right' ) ); ?> columns header-right<?php if ( $meta_login == false ) { ?> no-meta-menu<?php } ?>">

--- a/style.css
+++ b/style.css
@@ -1763,7 +1763,11 @@ a:active {
 	max-height: 100px;
 	width: auto;
 }
-.site-branding .site-title {
+.site-branding h1.site-title,
+.site-branding p.site-title {
+	font-size: 3.2rem;
+	font-family: var(--memberlite-header-font);
+	line-height: 4.4rem;
 	margin: 0;
 }
 .site-branding .site-title a {
@@ -1775,6 +1779,7 @@ a:active {
 	color: var(--memberlite-color-header-text);
 	display: block;
 	font-style: italic;
+	margin: 0;
 }
 .header-right {
 	text-align: right;


### PR DESCRIPTION
…sibility.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

SEO scans were reporting duplicate h1s on pages in Memberlite themed sites. We had a conversation about this from an Accessibility and SEO perspective on twitter and the resounding feedback was the use <h1> for the page title on the homepage only. Interior pages will now wrap the page title in the <p> tag. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Improved page title html structure for accessibility and SEO.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
