### PR TITLE
Putting back a lost separator that was in the theme when sites show excerpt distinct from post content on single.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -262,8 +262,13 @@ function memberlite_the_content( $content ) {
 		$morespan_pos = strpos( $content, $morespan );
 		$leadcontent = substr( $content, 0, $morespan_pos );
 
+		// Add the block image between the "excerpt" and the rest of the content.
+		if ( ! empty( $image_content ) ) {
+			$leadcontent .= $image_content;
+		}
+
 		/**
-		 * Filter to turn off the enlarged/enhanced excerpt text for a single post.
+		 * Filter to turn off the enlarged/enhanced excerpt text for a single post with a separator.
 		 *
 		 * @since 4.5.4
 		 *
@@ -273,12 +278,7 @@ function memberlite_the_content( $content ) {
 		 */
 		$memberlite_excerpt_larger = apply_filters( 'memberlite_excerpt_larger', true);
 		if ( ! empty( $memberlite_excerpt_larger ) ) {
-			$leadcontent = '<div class="lead">' . $leadcontent . '</div>';
-		}
-
-		// Add the block image between the "excerpt" and the rest of the content.
-		if ( ! empty( $image_content ) ) {
-			$leadcontent .= $image_content;
+			$leadcontent = '<div class="lead">' . $leadcontent . '<hr /></div>';
 		}
 
 		// Add the content after the $more tag to the $content.

--- a/style.css
+++ b/style.css
@@ -646,6 +646,7 @@ a.btn.skip-link {
 	padding: .7rem 1.45rem;
 }
 a.pmpro_btn,
+a.pmpro_btn:link,
 .pmpro_content_message a,
 input[type=submit].pmpro_btn,
 input[type=button].pmpro_btn,
@@ -1656,7 +1657,7 @@ a:active {
 #secondary .widget {
 	margin-bottom: 2.9rem;
 }
-.widget-area .widget a:not(.btn) {
+.widget-area .widget a:not(.btn):not(.pmpro_btn) {
 	border-bottom: 1px dotted var(--memberlite-color-white);
 	text-decoration: none;
 	color: var(--memberlite-color-text);

--- a/style.css
+++ b/style.css
@@ -2280,6 +2280,9 @@ a:active {
 	font-weight: bold;
 	margin: 0;
 }
+.hentry .entry-content .lead .wp-post-image {
+	margin-bottom: 0;
+}
 .entry-content,
 .entry-summary {
 	margin: 0;


### PR DESCRIPTION
In the update to add block images to the excerpts, the "separator" between the excerpt and full post content (if you aren't disabling this feature using the `memberlite_excerpt_larger` filter) was lost.

This PR replaces that lost separator.