### PR TITLE
Jetpack lazy load fix for duplicate author avatars

### DIFF
--- a/components/post/entry-header.php
+++ b/components/post/entry-header.php
@@ -47,7 +47,8 @@
 					'src' => array(),
 					'title' => array(),
 					'width' => array()
-				)
+				),
+				'noscript' => array()
 			);
 			echo wp_kses( memberlite_get_author_avatar( $post->post_author ), $author_avatar_allowed_html );
 		?>

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -471,7 +471,8 @@ function memberlite_page_title( $echo = true ) {
 						'src' => array(),
 						'title' => array(),
 						'width' => array()
-					)
+					),
+					'noscript' => array()
 				);
 				echo wp_kses( memberlite_get_author_avatar( $post->post_author ), $author_avatar_allowed_html );
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes two locations where the author avatar is output and may result in duplicate images when using the JetPack Boost - Lazy Load feature.  See this .org support ticket where another theme had the same issue for reference: https://wordpress.org/support/topic/author-image-signature-displayed-twice-after-a-post/#post-12096318

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Improved escaping for author avatars to prevent duplicate images when using JetPack Boost - Lazy Load.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
