### PR TITLE
Fixes a PHP Deprecated notice

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -885,7 +885,7 @@ function memberlite_should_show_banner_image( $post_id = null ) {
  * Get the post thumbnail image src and allow filtering.
  * Used to swap in the banner for loop/single posts with Memberlite Elements.
  */
-function memberlite_get_banner_image( $attachment_id, $size = 'banner', $icon = false, $attr = '', $post_id ) {
+function memberlite_get_banner_image( $attachment_id = 0, $size = 'banner', $icon = false, $attr = '', $post_id = 0 ) {
 	// default to global post
 	if ( empty( $attachment_id ) ) {
 		global $post;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a PHP Deprecated notice that occurs on the admin page

Deprecated: Required parameter $post_id follows optional parameter $size in C:\Users\info\Local Sites\paid-memberships-pro\app\public\wp-content\themes\memberlite\inc\extras.php on line 887

Memberlite: 4.5.4.1
PHP: 8.0.22

![image](https://user-images.githubusercontent.com/8989542/213987928-7def22b2-fa01-49b4-b814-3b7be06692ba.png)


### How to test the changes in this Pull Request:

1. Set up Memberlite and ensure PHP 8.0.22 is running
2. Login to wp-admin - there should be no admin notices

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes PHP deprecated notice errors.
