### PR TITLE
Required Parameters can't be present after optional params

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -885,7 +885,7 @@ function memberlite_should_show_banner_image( $post_id = null ) {
  * Get the post thumbnail image src and allow filtering.
  * Used to swap in the banner for loop/single posts with Memberlite Elements.
  */
-function memberlite_get_banner_image( $attachment_id, $size = 'banner', $icon = false, $attr = '', $post_id ) {
+function memberlite_get_banner_image( $attachment_id, $size = 'banner', $icon = false, $attr = '', $post_id = 0 ) {
 	// default to global post
 	if ( empty( $attachment_id ) ) {
 		global $post;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Required params need a default value otherwise an error is thrown in PHP8

This resolves the following errors which show up on every page:

```
Deprecated: Optional parameter $size declared before required parameter $post_id is implicitly treated as a required parameter in C:\Users\info\Local Sites\paid-memberships-pro\app\public\wp-content\themes\memberlite\inc\extras.php on line 888

Deprecated: Optional parameter $icon declared before required parameter $post_id is implicitly treated as a required parameter in C:\Users\info\Local Sites\paid-memberships-pro\app\public\wp-content\themes\memberlite\inc\extras.php on line 888

Deprecated: Optional parameter $attr declared before required parameter $post_id is implicitly treated as a required parameter in C:\Users\info\Local Sites\paid-memberships-pro\app\public\wp-content\themes\memberlite\inc\extras.php on line 888
```

### How to test the changes in this Pull Request:

1. Make use of PHP8+
2. Load any page and the errors would normally show at the top

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes PHP8 errors
