### PR TITLE
Add support for non .org recommended products.

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -95,9 +95,10 @@ function memberlite_support() {
 					'a' => array(
 						'class' => array(),
 						'href' => array(),
+						'target' => array()
 					),
 				);
-				$memberlite_plugins_recommended = apply_filters( 'memberlite_plugins_recommended', array( 'paid-memberships-pro', 'sitewide-sales' ) );
+				$memberlite_plugins_recommended = apply_filters( 'memberlite_plugins_recommended', array( 'paid-memberships-pro', 'sitewide-sales'  ) );
 				if ( ! empty( $memberlite_plugins_recommended ) ) { ?>
 					<hr />
 					<h2>
@@ -120,7 +121,7 @@ function memberlite_support() {
 										<ul class="plugin-action-buttons">
 											<li>
 												<?php
-													echo wp_kses( memberlite_plugin_action_button( 'paid-memberships-pro', 'paid-memberships-pro/paid-memberships-pro.php' ), $memberlite_plugin_action_button_allowed_html );
+													echo wp_kses( memberlite_plugin_action_button( 'paid-memberships-pro', 'paid-memberships-pro/paid-memberships-pro.php', 'https://www.paidmembershipspro.com/documentation/download/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage' ), $memberlite_plugin_action_button_allowed_html );
 												?>
 											</li>
 											<li><a href="https://www.paidmembershipspro.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'More Details', 'memberlite' ); ?></a></li>
@@ -145,7 +146,7 @@ function memberlite_support() {
 										<ul class="plugin-action-buttons">
 											<li>
 												<?php
-													echo wp_kses( memberlite_plugin_action_button( 'sitewide-sales', 'sitewide-sales/sitewide-sales.php' ), $memberlite_plugin_action_button_allowed_html );
+													echo wp_kses( memberlite_plugin_action_button( 'sitewide-sales', 'sitewide-sales/sitewide-sales.php', 'https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage' ), $memberlite_plugin_action_button_allowed_html );
 												?>
 											</li>
 											<li><a href="https://sitewidesales.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'More Details', 'memberlite' ); ?></a></li>
@@ -264,7 +265,7 @@ function memberlite_support() {
 									<ul class="plugin-action-buttons">
 										<li>
 											<?php
-												echo wp_kses( memberlite_plugin_action_button( 'paid-memberships-pro', 'paid-memberships-pro/paid-memberships-pro.php' ), $memberlite_plugin_action_button_allowed_html );
+												echo wp_kses( memberlite_plugin_action_button( 'paid-memberships-pro', 'paid-memberships-pro/paid-memberships-pro.php', 'https://www.paidmembershipspro.com/documentation/download/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage' ), $memberlite_plugin_action_button_allowed_html );
 											?>
 										</li>
 										<li><a href="https://www.paidmembershipspro.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage" target="_blank"><?php esc_html_e( 'More Details', 'memberlite' ); ?></a></li>
@@ -289,8 +290,11 @@ function memberlite_support() {
 
 /**
  * Show an action button for the specified plugin
+ * @param string $slug The plugin slug
+ * @param string $plugin_file The plugin file (includes slug/plugin.php)
+ * @param string $download_link Get the download link for the plugin. If 'org' is set assume it's on WordPress.org and search in the WP dashboard for the plugin.
  */
-function memberlite_plugin_action_button( $slug, $plugin_file ) {
+function memberlite_plugin_action_button( $slug, $plugin_file, $download_link = 'org' ) {
 	$plugin_file_abs = ABSPATH . 'wp-content/plugins/' . $plugin_file;
 	if ( is_plugin_active( $plugin_file ) ) {
 		$status = 'active';
@@ -305,12 +309,17 @@ function memberlite_plugin_action_button( $slug, $plugin_file ) {
 	} elseif ( $status === 'inactive' ) {
 		$r = '<a class="install-now button" href="' . esc_url( add_query_arg( array( 's' => $slug ), admin_url( 'plugins.php' ) ) ) . '">' . __( 'Activate', 'memberlite' ) . '</a>';
 	} else {
-		if ( is_multisite() ) {
-			// This is a network install.
-			$r = '<a class="install-now button" href="' . esc_url( add_query_arg( array( 's' => $slug, 'tab' => 'search' ), network_admin_url( 'plugin-install.php' ) ) ) . '">' . __( 'Install', 'memberlite' ) . '</a>';
+		// Adjust the download link based on the download_link that is passed in.
+		if ( $download_link === 'org' ) {
+			$plugin_url = is_multisite() ? add_query_arg( array( 's' => $slug, 'tab' => 'search' ), network_admin_url( 'plugin-install.php' ) ) : add_query_arg( array( 's' => $slug, 'tab' => 'search' ), admin_url( 'plugin-install.php' ) );
+			$target = '';
 		} else {
-			$r = '<a class="install-now button" href="' . esc_url( add_query_arg( array( 's' => $slug, 'tab' => 'search' ), admin_url( 'plugin-install.php' ) ) ) . '">' . __( 'Install', 'memberlite' ) . '</a>';
+			$plugin_url = $download_link;
+			$target = ' target=_blank'; // esc_attr is wrapping the values in between quotes when outputting so we can ommit them here.
 		}
+
+		$r = '<a href="' . esc_url( $plugin_url ) . '" class="install-now button" aria-label="' . esc_attr__( 'Install', 'memberlite' ) . '"' . esc_attr( $target ) . '>' . __( 'Install', 'memberlite' ) . '</a>';
+		
 	}
 	return $r;
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -98,7 +98,7 @@ function memberlite_support() {
 						'target' => array()
 					),
 				);
-				$memberlite_plugins_recommended = apply_filters( 'memberlite_plugins_recommended', array( 'paid-memberships-pro', 'sitewide-sales'  ) );
+				$memberlite_plugins_recommended = apply_filters( 'memberlite_plugins_recommended', array( 'paid-memberships-pro', 'sitewide-sales' ) );
 				if ( ! empty( $memberlite_plugins_recommended ) ) { ?>
 					<hr />
 					<h2>
@@ -146,7 +146,7 @@ function memberlite_support() {
 										<ul class="plugin-action-buttons">
 											<li>
 												<?php
-													echo wp_kses( memberlite_plugin_action_button( 'sitewide-sales', 'sitewide-sales/sitewide-sales.php', 'https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage' ), $memberlite_plugin_action_button_allowed_html );
+													echo wp_kses( memberlite_plugin_action_button( 'sitewide-sales', 'sitewide-sales/sitewide-sales.php', 'https://sitewidesales.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage' ), $memberlite_plugin_action_button_allowed_html );
 												?>
 											</li>
 											<li><a href="https://sitewidesales.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'More Details', 'memberlite' ); ?></a></li>
@@ -154,7 +154,7 @@ function memberlite_support() {
 									</div>
 									<div class="desc column-description">
 										<p><?php esc_html_e( 'All-in-one flash sales plugin for WordPress. Set up a sale from a single settings page: select the start and end date, choose a template, pick your banner, and assign the discount.', 'memberlite' ); ?></p>
-										<p class="authors"><cite><?php esc_html_e( 'By', 'memberlite' ); ?> <?php esc_html_e( 'Stranger Studios', 'memberlite' ); ?></cite></p>
+										<p class="authors"><cite><?php esc_html_e( 'By', 'memberlite' ); ?> <a href="https://www.strangerstudios.com/?utm_source=memberlite-theme&utm_medium=memberlite-guide&utm_campaign=homepage" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Stranger Studios', 'memberlite' ); ?></a></cite></p>
 									</div>
 								</div>
 							</div> <!-- end plugin-card-sitewide-sales -->


### PR DESCRIPTION
* ENHANCEMENT: Added logic to the Memberlite Guide page to support products privately hosted (not on .org).

Tweaks were made to the function `memberlite_plugin_action_button` to take a third parameter and pass in a download link. If this download link is present it also opens in a new tab so people may download and install the product, the default value is "org".

This keeps uniformity in the functionality of finding the plugin in the plugins.php search in the WordPress dashboard and we may not need a complete solution to download and install the plugin automatically. We could possibly install the .zip for Paid Memberships Pro or other free plugins not hosted on .org - it felt right to get them to a landing page if they do follow this flow of installing PMPro or SWS.

Both Paid Memberships Pro and Sitewide Sales are not currently found at all if you use the "Install" button on the block, it redirects to the install plugins page and no plugin is found. 

Questions:
* We can also change the word "Install" to "View Product/Download" (or similar) since it's not installing but redirecting users to download or purchase the products.
* UTM parameters were added and kept the same across URLs, these are existing UTM parameters. These may need to be updated.
* URLS for non .org plugins go to the download page, we can adjust this to other landing pages if needed.
* non .org download URLs will always be open in a new window. 

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?