### PR TITLE
Move memberlite_load_textdomain() to init

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -218,12 +218,6 @@ if ( ! function_exists( 'memberlite_setup' ) ) :
 		require_once get_template_directory() . '/inc/defaults.php';
 
 		global $memberlite_defaults;
-		/*
-		 * Make theme available for translation.
-		 * If you're building a theme based on Memberlite, use a find and replace
-		 * to change 'memberlite' to the name of your theme in all the template files
-		 */
-		load_theme_textdomain( 'memberlite' );
 
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );
@@ -470,6 +464,17 @@ if ( ! function_exists( 'memberlite_setup' ) ) :
 	}
 endif; // memberlite_setup
 add_action( 'after_setup_theme', 'memberlite_setup' );
+
+/**
+ * Load the Memberlite theme textdomain on init (WP 6.7+ requirement).
+ * 
+ * If you're building a theme based on Memberlite, use a find and replace
+ * to change 'memberlite' to the name of your theme in all the template files.
+ */
+function memberlite_load_textdomain() {
+    load_theme_textdomain( 'memberlite', get_template_directory() . '/languages' );
+}
+add_action( 'init', 'memberlite_load_textdomain' );
 
 /**
  * Load custom translations from our own server: translate.strangerstudios.com


### PR DESCRIPTION
I moved the load_theme_textdomain() call from after_setup_theme to init to comply with the updated WordPress 6.7+ requirement, which eliminates a debug warning.

### All Submissions:

* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Using Master or the current theme version, enable WP_DEBUG locally in WordPress 6.7 or higher.
2. Observe in the debug log the warning: 
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
