### PR TITLE
Fix for nested cards coming to signup shortcode in future release

### DIFF
--- a/style.css
+++ b/style.css
@@ -2917,6 +2917,11 @@ a:active:not(.pmpro_btn:active) {
 	border-bottom: 1.45rem solid var(--memberlite-color-secondary);
 }
 
+.pmpro .pmpro_signup_form .pmpro_card .pmpro_card {
+	border-top: none;
+	border-bottom: none;
+}
+
 /* Membership Checkout */
 #secondary form.pmpro_form .pmpro_submit {
 	text-align: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Signup Shortcode is getting an update to show checkout boxes. For that update, we also have code coming to core PMPro to zero out formatting on the card style when there is a card inside another card. This PR fixes that for the Signup Shortcode's special formatting in Memberlite.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fix display of Signup Shortcode borders when there is a nested `pmpro_card`.