### PR TITLE
Import and export theme settings fixed to support child theme export /  import to parent theme and vice versa

### DIFF
--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -204,7 +204,7 @@ function memberlite_import_theme_settings() {
 	$current_stylesheet = get_option( 'stylesheet' );
 
 	// Ensure the file is for this theme (or a child of the same parent theme).
-	// Check against both template and stylesheet for backwards compatibility with older exports.
+	// Check against both template and stylesheet for backwards compatibility with older exports from parent theme installations.
 	if ( $data['template'] !== $current_template && $data['template'] !== $current_stylesheet ) {
 		memberlite_import_settings_redirect( 'wrong_theme' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Improves the theme import and export settings functionality to support settings imported or exported between child themes or Memberlite sites without child themes.

The export file now includes a "template" attribute, which should always be the parent theme ("memberlite") slug, instead of the child theme slug

### How to test the changes in this Pull Request:

1. Export theme settings from a site using a Memberlite child theme
2. Try to import them into a site not using a child theme or using a different named child theme
3. Without this code, the validator would flag this as a wrong theme.
4. With this code, the validator will successfully import the theme settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Now supporting theme settings import and export between child themes and parent themes.
