### PR TITLE
turn enlarge excerpt off by default

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -298,16 +298,16 @@ function memberlite_the_content( $content ) {
 		}
 
 		/**
-		 * Filter to turn off the enlarged/enhanced excerpt text for a single post with a separator.
-		 * Will be turned off by default. Child themes/plugins can use this filter to turn it back on.
+		 * Filter to turn enlarge/enhance the excerpt text for a single post with a separator.
 		 *
 		 * @since 4.5.4
+		 * @since TBD Reversed filter default to `false` in TBD
 		 *
 		 * @param bool $memberlite_excerpt_larger Enlarge/enhance the excerpt text on a single post.
 		 * @return bool $memberlite_excerpt_larger
 		 *
 		 */
-		$memberlite_excerpt_larger = apply_filters( 'memberlite_excerpt_larger', false);
+		$memberlite_excerpt_larger = apply_filters( 'memberlite_excerpt_larger', false );
 		if ( ! empty( $memberlite_excerpt_larger ) ) {
 			$leadcontent = '<div class="lead">' . $leadcontent . '<hr /></div>';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Turn the existing `memberlite_excerpt_larger` off by default by passing `false`. People can still hook into the filter to turn it back on.

### How to test the changes in this Pull Request:

1. Check out the `memberlite-7-0` branch locally
2. Navigate to an archive page on the front-end. Posts archive, category archive etc.
3. Each post should have larger text above the featured image/at the start of the post, and when you inspect it from the browser inspector, it'll be wrapped in a `div` with a `lead` class.
4. Switch to this branch.
5. That same area on the post should no longer be enlarged. That div wrapper will no longer exist. It'll just show regular content.

**What it looks like with the filter on before we turned it off:**

<img width="1157" height="880" alt="image" src="https://github.com/user-attachments/assets/f2645c55-1155-4000-b883-f60611065c4a" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Turn the existing `memberlite_excerpt_larger` off by default by passing `false`.
