### PR TITLE
Update the import function so that it properly handles legacy colors before saving to theme mods

### DIFF
--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -218,7 +218,15 @@ function memberlite_import_theme_settings() {
 		foreach ( $data['mods'] as $key => $value ) {
 			// Sanitize color values to remove # prefix
 			if ( in_array( $key, $color_keys, true ) && is_string( $value ) ) {
-				$value = ltrim( $value, '#' );
+				$value = sanitize_hex_color_no_hash( $value );
+
+				// Skip if sanitization failed (returns null for invalid colors)
+				if ( $value === null ) {
+					continue;
+				}
+
+				// Lowercase for consistency
+				$value = strtolower( $value );
 			}
 
 			set_theme_mod( $key, $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated the `memberlite_import_theme_settings` function so when someone imports theme settings from another Memberlite site, colors are saved without the hashes. Also checks if the color scheme is legacy, and if so, sets to "custom."

### How to test the changes in this Pull Request:

You'll either need two different environments with the Memberlite theme -- one with this branch checked out and another with the `dev` branch that still has the legacy color schemes. Or, you can use the same environment and just switch between branches, but I find having separate ones easier to confirm.

1. On your "legacy" site (`dev` branch), on the WP-Admin, go to Appearance > Customize > Colors. Select a legacy color scheme if one isn't already selected and publish.
2. Then exit the Customizer. Go to Memberlite > Tools > Export Theme Settings. Click the button to export. It will download a JSON file.
3. Now navigate to this branch `migrate-colors-import` (or environment). This branch has modern color schemes. If it doesn't, you can either go to Memberlite > Tools > Reset Theme Settings, and reset -- or -- go to Appearance > Customizer > Colors and select one of the modern color schemes, and publish.
4. Now go to Memberlite > Tools > Import Theme Settings.
5. Select the JSON file you had downloaded. Click the "Import Theme Settings" button.
6. The front-end should now reflect the imported color scheme. Check the customizer. A legacy color scheme will be saved as "custom" in the color scheme setting.

**Test custom legacy scheme:**

You can also test changing colors on your legacy site with a legacy scheme active so it saves as "custom." Then import to your "modern" site and confirm that colors are intact, and the scheme is still "custom." 

**Test modern to modern color scheme:**

You can also stay on your "modern" site, set a modern color scheme, and publish. Export theme settings. Then change your color scheme to a different modern color scheme intentionally. It's easier to see the change with two different color schemes. Import the file from when you exported with a modern color scheme. Changes should reflect on the front-end, and the customizer should be set to the correct color scheme (Evergreen, Deep Harbor etc.).

**Test a malformed color scheme:**

Edit the JSON file that you've downloaded as an export by opening it in your IDE or Notepad. Look for the `memberlite_color_scheme` key, and in the value, set it to `{"scheme":"pop"}` for example. This value should always be a string, but this is to test what happens when it isn't. When you import this malformed JSON, the rest of the color settings should import, but the color scheme will set to "custom."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated the `memberlite_import_theme_settings` function so that color settings save without the hash and color schemes are set properly.
