### PR TITLE
Adding defensive check to wp_block menu item

### DIFF
--- a/inc/patterns.php
+++ b/inc/patterns.php
@@ -40,6 +40,17 @@ add_action( 'init', 'memberlite_register_pattern_categories' );
  * @return void
  */
 function memberlite_add_patterns_menu_item(): void {
+	global $menu;
+
+	// Bail if there is already a menu item for wp_block.
+	if ( is_array( $menu ) ) {
+		foreach ( $menu as $menu_item ) {
+			if ( isset( $menu_item[2] ) && 'edit.php?post_type=wp_block' === $menu_item[2] ) {
+				return;
+			}
+		}
+	}
+
 	add_menu_page(
 		__( 'Patterns', 'memberlite' ),
 		__( 'Patterns', 'memberlite' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If a site was already showing a link to the "Patterns" (`wp_block`) post type, Memberlite would add an additional link.

This PR adds a defensive check to only add that link if it isn't already present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed issue where Memberlite might add a duplicate Patterns admin menu link.
