### PR TITLE
BUG FIX: Prevent duplicate Patterns menu item in admin

### DIFF
--- a/inc/patterns.php
+++ b/inc/patterns.php
@@ -40,6 +40,17 @@ add_action( 'init', 'memberlite_register_pattern_categories' );
  * @return void
  */
 function memberlite_add_patterns_menu_item(): void {
+	global $menu;
+
+	// Bail if another plugin or theme already added a menu item for wp_block.
+	if ( is_array( $menu ) ) {
+		foreach ( $menu as $menu_item ) {
+			if ( isset( $menu_item[2] ) && 'edit.php?post_type=wp_block' === $menu_item[2] ) {
+				return;
+			}
+		}
+	}
+
 	add_menu_page(
 		__( 'Patterns', 'memberlite' ),
 		__( 'Patterns', 'memberlite' ),


### PR DESCRIPTION
## Summary

Memberlite 7.0 adds a "Patterns" menu item for the `wp_block` post type via `memberlite_add_patterns_menu_item()`. If a child theme or custom snippet already registers the same menu item (using `add_menu_page()` with `edit.php?post_type=wp_block`), it appears twice in the admin menu.

This adds a defensive check — before calling `add_menu_page()`, we scan the global `$menu` array. If `edit.php?post_type=wp_block` is already registered, we bail early.

## Example of conflicting custom code

```php
function my_patterns_admin_menu() {
    add_menu_page( 'Patterns', 'Patterns', 'edit_posts', 'edit.php?post_type=wp_block', '', 'dashicons-editor-table', 22 );
}
add_action( 'admin_menu', 'my_patterns_admin_menu' );
```

## Test plan

- [ ] Activate Memberlite 7.0 — confirm Patterns menu item still appears once
- [ ] Add the custom code snippet above to a child theme or mu-plugin — confirm Patterns menu item still appears only once (the custom one takes precedence since Memberlite bails)
- [ ] Remove the custom snippet — confirm Memberlite's menu item returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)