### PR TITLE
Resolve memberlite_load_local_webfonts bug and make sure fonts from customizer/blocks are recognized

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -107,8 +107,16 @@ function memberlite_load_local_webfonts() {
 
 	// If it's not a Google font, ignore.
 	$google_fonts = array_map( 'strtolower', array_keys( Memberlite_Customize::get_google_fonts() ) );
-	if ( ! in_array( $header_font, $google_fonts ) && ! in_array( $body_font, $google_fonts ) ) {
+	if ( ! in_array( $header_font, $google_fonts, true ) && ! in_array( $body_font, $google_fonts, true ) ) {
 		return;
+	}
+
+	// Disable any font that is not a Google font so no @font-face is emitted for it.
+	if ( ! in_array( $header_font, $google_fonts, true ) ) {
+		$header_font = false;
+	}
+	if ( ! in_array( $body_font, $google_fonts, true ) ) {
+		$body_font = false;
 	}
 
 	// If the header and body fonts are the same, just load the body font.
@@ -130,7 +138,7 @@ src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $b
 font-weight: normal;
 font-display: fallback;
 font-stretch: normal;
-}<?php if ( ! in_array( $body_font, $no_bold_font ) ) { ?>@font-face {
+}<?php if ( ! in_array( $body_font, $no_bold_font, true ) ) { ?>@font-face {
 font-family: <?php echo esc_html( memberlite_get_font( 'body_font', true ) ); ?>;
 font-style:normal;
 src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $body_font ) . '/' . esc_html( $body_font ) . '-bold.woff2'; ?>') format('woff2');
@@ -149,7 +157,7 @@ src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $h
 font-weight: normal;
 font-display: fallback;
 font-stretch: normal;
-}<?php if ( ! in_array( $header_font, $no_bold_font ) ) { ?>@font-face {
+}<?php if ( ! in_array( $header_font, $no_bold_font, true ) ) { ?>@font-face {
 font-family: <?php echo esc_html( memberlite_get_font( 'header_font', true ) ); ?>;
 font-style:normal;
 src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $header_font ) . '/' . esc_html( $header_font ) . '-bold.woff2'; ?>') format('woff2');

--- a/functions.php
+++ b/functions.php
@@ -83,9 +83,15 @@ function memberlite_get_font( $font_type, $nicename = NULL ) {
 	// Get the selected fonts from theme options.
 	$r = get_theme_mod( 'memberlite_' . $font_type, $memberlite_defaults[ 'memberlite_' . $font_type ] );
 
-	// If we're returning the font name, convert the slug to a human-readable name.
+	// If we're returning the font name, look up the exact display name from the font list.
 	if ( ! empty( $nicename ) ) {
-		$r = ucwords( str_replace( '-', ' ', $r ) );
+		$lower_slug = strtolower( $r );
+		foreach ( Memberlite_Customize::get_all_fonts() as $slug => $name ) {
+			if ( strtolower( $slug ) === $lower_slug ) {
+				$r = $name;
+				break;
+			}
+		}
 	}
 
 	return $r;
@@ -100,7 +106,7 @@ function memberlite_load_local_webfonts() {
 	$body_font = strtolower( memberlite_get_font( 'body_font' ) );
 
 	// If it's not a Google font, ignore.
-	$google_fonts = array_keys( Memberlite_Customize::get_google_fonts() );
+	$google_fonts = array_map( 'strtolower', array_keys( Memberlite_Customize::get_google_fonts() ) );
 	if ( ! in_array( $header_font, $google_fonts ) && ! in_array( $body_font, $google_fonts ) ) {
 		return;
 	}

--- a/functions.php
+++ b/functions.php
@@ -85,7 +85,7 @@ function memberlite_get_font( $font_type, $nicename = NULL ) {
 
 	// If we're returning the font name, convert the slug to a human-readable name.
 	if ( ! empty( $nicename ) ) {
-		$r = str_replace( '-', ' ', $r );
+		$r = ucwords( str_replace( '-', ' ', $r ) );
 	}
 
 	return $r;
@@ -95,15 +95,13 @@ function memberlite_get_font( $font_type, $nicename = NULL ) {
  * Load locally hosted Google fonts used in site.
  */
 function memberlite_load_local_webfonts() {
-	global $memberlite_defaults;
-
 	// Get the selected fonts from theme options.
 	$header_font = strtolower( memberlite_get_font( 'header_font' ) );
 	$body_font = strtolower( memberlite_get_font( 'body_font' ) );
 
 	// If it's not a Google font, ignore.
-	$fonts_string = $header_font . '_' . $body_font;
-	if ( ! in_array( $fonts_string, array_keys( Memberlite_Customize::get_google_fonts() ) ) ) {
+	$google_fonts = array_keys( Memberlite_Customize::get_google_fonts() );
+	if ( ! in_array( $header_font, $google_fonts ) && ! in_array( $body_font, $google_fonts ) ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**First Bug Resolved:** The `get_google_fonts` function always returns early and never outputs a single `@font-face` declaration. This is because `get_google_fonts()` returns individual font keys like `montserrat`, `lato`, `open-sans`, etc. The code builds a combined string like `montserrat_lato` and checks if that exists as a key — it never will.

**Second Bug Resolved:** The `memberlite_get_font` function outputs font family names via slug-to-nicename conversion (`dm-sans` → `dm sans`) while `theme.json` correctly declares "DM Sans". These won't match exactly, which means if both are active simultaneously for the same font, you'll get two `@font-face` declarations — one with `font-family: dm sans` and one with `font-family: "DM Sans"`. The browser treats them as different families.

**Third Bug Resolved:** Null out $header_font/$body_font before @font-face output if they are not in the Google fonts list, preventing broken asset requests for web-safe fonts (e.g. Arial). Also add strict mode (true) to all in_array() calls in the `memberlite_load_local_webfonts` function.

### How to test the changes in this Pull Request:

Make sure the fonts are loading/applying from Customizer and within the block editor settings. 👍 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix local webfont loading and ensure font selections coming from the Customizer and block/theme.json settings resolve to the same effective font-family, preventing missing fonts and duplicate @font-face declarations
