### PR TITLE
Add flex wrap to navigation menus in the header

### DIFF
--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -318,6 +318,7 @@
 			&.menu {
 				align-items: center;
 				display: flex;
+				flex-wrap: wrap;
 				margin: 0 auto;
 				z-index: 10;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds `flex-wrap` to navigation menus on desktop. Prevents weird breaking for long links/really long menus.

### How to test the changes in this Pull Request:

Either make your header navigation links multiple words or add like 10+ items to the navigation. View on a screen that's between mobile and desktop size. Links should wrap/break into the next line rather than the words themselves breaking.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add flex wrap to header menus for long links and long menus.
