### PR TITLE
Refactor so theme.json is the source of truth. Migration for theme mod formatting to new expected format

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -77,88 +77,58 @@ function memberlite_admin_enqueue_scripts() {
 }
 add_action( 'admin_enqueue_scripts', 'memberlite_admin_enqueue_scripts' );
 
-function memberlite_get_font( $font_type, $nicename = NULL ) {
+/**
+ * Get the selected font slug for a given font type.
+ *
+ * Returns the theme.json-compatible slug (lowercase). If $nicename is true,
+ * returns the display name by looking it up in the registered font families.
+ * Safe to call anywhere except from within the wp_theme_json_data_theme filter
+ * with $nicename = true (use memberlite_get_font_name_from_json_data() there instead).
+ *
+ * @param string    $font_type 'header_font' or 'body_font'.
+ * @param bool|null $nicename  Optional. If true, return the display name.
+ * @return string Font slug or display name.
+ */
+function memberlite_get_font( $font_type, $nicename = false ) {
 	global $memberlite_defaults;
 
-	// Get the selected fonts from theme options.
-	$r = get_theme_mod( 'memberlite_' . $font_type, $memberlite_defaults[ 'memberlite_' . $font_type ] );
+	$slug = strtolower( get_theme_mod( 'memberlite_' . $font_type, $memberlite_defaults[ 'memberlite_' . $font_type ] ) );
 
-	// If we're returning the font name, convert the slug to a human-readable name.
-	if ( ! empty( $nicename ) ) {
-		$r = str_replace( '-', ' ', $r );
+	if ( ! $nicename ) {
+		return $slug;
 	}
 
-	return $r;
+	// Look up the display name from theme.json font families.
+	$settings     = wp_get_global_settings();
+	$font_families = $settings['typography']['fontFamilies']['theme'] ?? array();
+	foreach ( $font_families as $font ) {
+		if ( $font['slug'] === $slug ) {
+			return $font['name'];
+		}
+	}
+
+	// Fallback: convert slug to title case.
+	return ucwords( str_replace( '-', ' ', $slug ) );
 }
 
 /**
- * Load locally hosted Google fonts used in site.
+ * Look up a font display name from a fontFamilies array.
+ *
+ * Used inside the wp_theme_json_data_theme filter to avoid circular calls
+ * to wp_get_global_settings().
+ *
+ * @param string $slug         The font slug to look up.
+ * @param array  $font_families Array of fontFamily objects from theme.json data.
+ * @return string Display name, or title-cased slug as fallback.
  */
-function memberlite_load_local_webfonts() {
-	global $memberlite_defaults;
-
-	// Get the selected fonts from theme options.
-	$header_font = strtolower( memberlite_get_font( 'header_font' ) );
-	$body_font = strtolower( memberlite_get_font( 'body_font' ) );
-
-	// If it's not a Google font, ignore.
-	$fonts_string = $header_font . '_' . $body_font;
-	if ( ! in_array( $fonts_string, array_keys( Memberlite_Customize::get_google_fonts() ) ) ) {
-		return;
-	}
-
-	// If the header and body fonts are the same, just load the body font.
-	if ( $body_font === $header_font ) {
-		$header_font = false;
-	}
-
-	// Fonts that do not have a bold (700 weight) font family.
-	$no_bold_font = array( 'abril-fatface', 'fjalla-one', 'pathway-gothic-one', 'pt-mono' );
-
-	// Wrapper style tag for CSS.
-	echo '<style id="memberlite-webfonts-inline-css" type="text/css">';
-
-	// Enqueue the body font.
-	if ( ! empty( $body_font ) ) { ?>@font-face {
-font-family: <?php echo esc_html( memberlite_get_font( 'body_font', true ) ); ?>;
-font-style:normal;
-src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $body_font ) . '/' . esc_html( $body_font ) . '.woff2'; ?>') format('woff2');
-font-weight: normal;
-font-display: fallback;
-font-stretch: normal;
-}<?php if ( ! in_array( $body_font, $no_bold_font ) ) { ?>@font-face {
-font-family: <?php echo esc_html( memberlite_get_font( 'body_font', true ) ); ?>;
-font-style:normal;
-src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $body_font ) . '/' . esc_html( $body_font ) . '-bold.woff2'; ?>') format('woff2');
-font-weight: bold;
-font-display: fallback;
-font-stretch: normal;
-}<?php
+function memberlite_get_font_name_from_json_data( $slug, $font_families ) {
+	foreach ( $font_families as $font ) {
+		if ( ( $font['slug'] ?? '' ) === $slug ) {
+			return $font['name'];
 		}
 	}
-
-	// Enqueue the header font.
-	if ( ! empty( $header_font ) ) { ?>@font-face {
-font-family: <?php echo esc_html( memberlite_get_font( 'header_font', true ) ); ?>;
-font-style:normal;
-src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $header_font ) . '/' . esc_html( $header_font ) . '.woff2'; ?>') format('woff2');
-font-weight: normal;
-font-display: fallback;
-font-stretch: normal;
-}<?php if ( ! in_array( $header_font, $no_bold_font ) ) { ?>@font-face {
-font-family: <?php echo esc_html( memberlite_get_font( 'header_font', true ) ); ?>;
-font-style:normal;
-src: url('<?php echo esc_url( MEMBERLITE_URL ) . '/assets/fonts/' . esc_html( $header_font ) . '/' . esc_html( $header_font ) . '-bold.woff2'; ?>') format('woff2');
-font-weight: bold;
-font-display: fallback;
-font-stretch: normal;
-}<?php
-		}
-	}
-
-	echo '</style>';
+	return ucwords( str_replace( '-', ' ', $slug ) );
 }
-add_action( 'wp_head', 'memberlite_load_local_webfonts' );
 
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.
@@ -799,8 +769,11 @@ function memberlite_filter_theme_json( $theme_json ) {
 		$theme_json_data['settings']['custom']['body'] = array();
 	}
 
-	$theme_json_data['settings']['custom']['heading']['fontFamily'] = memberlite_get_font( 'header_font', true );
-	$theme_json_data['settings']['custom']['body']['fontFamily'] = memberlite_get_font( 'body_font', true );
+	// Look up font display names directly from the theme.json data to avoid
+	// circular calls to wp_get_global_settings() inside this filter.
+	$font_families = $theme_json_data['settings']['typography']['fontFamilies'] ?? array();
+	$theme_json_data['settings']['custom']['heading']['fontFamily'] = memberlite_get_font_name_from_json_data( memberlite_get_font( 'header_font' ), $font_families );
+	$theme_json_data['settings']['custom']['body']['fontFamily']    = memberlite_get_font_name_from_json_data( memberlite_get_font( 'body_font' ), $font_families );
 
 	// Update the theme.json object.
 	return $theme_json->update_with( $theme_json_data );

--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,10 @@ function memberlite_get_font( $font_type, $nicename = false ) {
  */
 function memberlite_get_font_name_from_json_data( $slug, $font_families ) {
 	foreach ( $font_families as $font ) {
-		if ( ( $font['slug'] ?? '' ) === $slug ) {
+		if ( ! is_array( $font ) || empty( $font['slug'] ) || empty( $font['name'] ) ) {
+			continue;
+		}
+		if ( $font['slug'] === $slug ) {
 			return $font['name'];
 		}
 	}
@@ -774,7 +777,15 @@ function memberlite_filter_theme_json( $theme_json ) {
 
 	// Look up font display names directly from the theme.json data to avoid
 	// circular calls to wp_get_global_settings() inside this filter.
-	$font_families = $theme_json_data['settings']['typography']['fontFamilies'] ?? array();
+	// fontFamilies in raw theme.json data may be grouped (e.g. 'theme', 'default'),
+	// so flatten all groups into a single list before passing to the lookup function.
+	$font_families_grouped = $theme_json_data['settings']['typography']['fontFamilies'] ?? array();
+	$font_families         = array();
+	foreach ( $font_families_grouped as $group ) {
+		if ( is_array( $group ) ) {
+			$font_families = array_merge( $font_families, $group );
+		}
+	}
 	$theme_json_data['settings']['custom']['heading']['fontFamily'] = memberlite_get_font_name_from_json_data( memberlite_get_font( 'header_font' ), $font_families );
 	$theme_json_data['settings']['custom']['body']['fontFamily']    = memberlite_get_font_name_from_json_data( memberlite_get_font( 'body_font' ), $font_families );
 

--- a/functions.php
+++ b/functions.php
@@ -99,9 +99,12 @@ function memberlite_get_font( $font_type, $nicename = false ) {
 	}
 
 	// Look up the display name from theme.json font families.
-	$settings     = wp_get_global_settings();
+	$settings      = wp_get_global_settings();
 	$font_families = $settings['typography']['fontFamilies']['theme'] ?? array();
 	foreach ( $font_families as $font ) {
+		if ( ! is_array( $font ) || empty( $font['slug'] ) || empty( $font['name'] ) ) {
+			continue;
+		}
 		if ( $font['slug'] === $slug ) {
 			return $font['name'];
 		}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -786,7 +786,11 @@ class Memberlite_Customize {
 		$font_families = $settings['typography']['fontFamilies']['theme'] ?? array();
 		$fonts         = array();
 		foreach ( $font_families as $font ) {
-			$fonts[ $font['slug'] ] = $font['name'];
+			if ( ! is_array( $font ) || empty( $font['slug'] ) || empty( $font['name'] ) ) {
+				continue;
+			}
+			$slug          = sanitize_key( $font['slug'] );
+			$fonts[ $slug ] = $font['name'];
 		}
 		return $fonts;
 	}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -774,60 +774,21 @@ class Memberlite_Customize {
 	}
 
 	/**
-	 * Get Google fonts
-	 */
-	public static function get_google_fonts() {
-		return array(
-			'Abril-Fatface'      => __( 'Abril Fatface', 'memberlite' ),
-			'DM-Sans'            => __( 'DM Sans', 'memberlite' ),
-			'Figtree'            => __( 'Figtree', 'memberlite' ),
-			'Fjalla-One'         => __( 'Fjalla One', 'memberlite' ),
-			'Gentium-Book-Basic' => __( 'Gentium Book Basic', 'memberlite' ),
-			'Inter'              => __( 'Inter', 'memberlite' ),
-			'Lato'               => __( 'Lato', 'memberlite' ),
-			'Merriweather'       => __( 'Merriweather', 'memberlite' ),
-			'Montserrat'         => __( 'Montserrat', 'memberlite' ),
-			'Noto-Sans'          => __( 'Noto Sans', 'memberlite' ),
-			'Open-Sans'          => __( 'Open Sans', 'memberlite' ),
-			'Oswald'             => __( 'Oswald', 'memberlite' ),
-			'Pathway-Gothic-One' => __( 'Pathway Gothic One', 'memberlite' ),
-			'Playfair-Display'   => __( 'Playfair Display', 'memberlite' ),
-			'Poppins'            => __( 'Poppins', 'memberlite' ),
-			'PT-Mono'            => __( 'PT Mono', 'memberlite' ),
-			'PT-Sans'            => __( 'PT Sans', 'memberlite' ),
-			'PT-Serif'           => __( 'PT Serif', 'memberlite' ),
-			'Quattrocento'       => __( 'Quattrocento', 'memberlite' ),
-			'Roboto'             => __( 'Roboto', 'memberlite' ),
-			'Roboto-Slab'        => __( 'Roboto Slab', 'memberlite' ),
-			'Source-Sans-Pro'    => __( 'Source Sans Pro', 'memberlite' ),
-			'Ubuntu'             => __( 'Ubuntu', 'memberlite' ),
-		);
-	}
-
-	/**
-	 * Get array of web safe fonts
-	 */
-	public static function get_web_safe_fonts() {
-		return array(
-			'Arial'           => __( 'Arial', 'memberlite' ),
-			'Bookman'         => __( 'Bookman', 'memberlite' ),
-			'Courier'         => __( 'Courier', 'memberlite' ),
-			'Courier-New'     => __( 'Courier New', 'memberlite' ),
-			'Garamond'        => __( 'Garamond', 'memberlite' ),
-			'Georgia'         => __( 'Georgia', 'memberlite' ),
-			'Helvetica'       => __( 'Helvetica', 'memberlite' ),
-			'Times'           => __( 'Times', 'memberlite' ),
-			'Times-New-Roman' => __( 'Times New Roman', 'memberlite' ),
-			'Trebuchet-MS'    => __( 'Trebuchet MS', 'memberlite' ),
-			'Verdana'         => __( 'Verdana', 'memberlite' ),
-		);
-	}
-
-	/**
-	 * Get array of all fonts
+	 * Get all available fonts from theme.json font families.
+	 *
+	 * theme.json is the single source of truth for available fonts. Developers
+	 * can add fonts by filtering wp_theme_json_data_theme.
+	 *
+	 * @return array Associative array of slug => display name.
 	 */
 	public static function get_all_fonts() {
-		return array_merge( Memberlite_Customize::get_google_fonts(), Memberlite_Customize::get_web_safe_fonts() );
+		$settings      = wp_get_global_settings();
+		$font_families = $settings['typography']['fontFamilies']['theme'] ?? array();
+		$fonts         = array();
+		foreach ( $font_families as $font ) {
+			$fonts[ $font['slug'] ] = $font['name'];
+		}
+		return $fonts;
 	}
 
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -789,7 +789,10 @@ class Memberlite_Customize {
 			if ( ! is_array( $font ) || empty( $font['slug'] ) || empty( $font['name'] ) ) {
 				continue;
 			}
-			$slug          = sanitize_key( $font['slug'] );
+			$slug = sanitize_key( $font['slug'] );
+			if ( '' === $slug ) {
+				continue;
+			}
 			$fonts[ $slug ] = $font['name'];
 		}
 		return $fonts;

--- a/inc/defaults.php
+++ b/inc/defaults.php
@@ -10,8 +10,8 @@
 function memberlite_get_defaults(): array {
 	$defaults = array(
 		// Typography
-		'memberlite_header_font'            => 'Lato',
-		'memberlite_body_font'              => 'Lato',
+		'memberlite_header_font'            => 'lato',
+		'memberlite_body_font'              => 'lato',
 
 		// Layout
 		'columns_ratio'                     => '8-4',

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -43,6 +43,17 @@ function memberlite_checkForUpdates() {
 		require_once get_template_directory() . '/inc/updates/update_7_0.php';
 		update_option( 'memberlite_db_version', '2026022201', 'no' );
 	}
+
+	// Migrate font theme_mods to lowercase slugs to match theme.json.
+	if ( $memberlite_db_version < '2026032601' ) {
+		foreach ( array( 'memberlite_header_font', 'memberlite_body_font' ) as $mod_key ) {
+			$value = get_theme_mod( $mod_key );
+			if ( ! empty( $value ) ) {
+				set_theme_mod( $mod_key, strtolower( $value ) );
+			}
+		}
+		update_option( 'memberlite_db_version', '2026032601', 'no' );
+	}
 }
 
 /**

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -49,7 +49,12 @@ function memberlite_checkForUpdates() {
 		foreach ( array( 'memberlite_header_font', 'memberlite_body_font' ) as $mod_key ) {
 			$value = get_theme_mod( $mod_key );
 			if ( ! empty( $value ) ) {
-				set_theme_mod( $mod_key, strtolower( $value ) );
+				$new_value = strtolower( $value );
+				// Map legacy "Courier" slug to "courier-new" to match theme.json.
+				if ( 'courier' === $new_value ) {
+					$new_value = 'courier-new';
+				}
+				set_theme_mod( $mod_key, $new_value );
 			}
 		}
 		update_option( 'memberlite_db_version', '2026032601', 'no' );

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Memberlite ===
 Contributors: kimannwall, strangerstudios
-Requires at least: 6.0
+Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 7.0

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Stranger Studios
 Author URI: https://www.strangerstudios.com
 Description: Memberlite is the ideal theme for your membership site - packed with integration for top plugins including Paid Memberships Pro and LifterLMS. It's fully customizable with your logo, colors, fonts, custom sidebars and more global layout settings. Extend the site appearance further with icons, masthead banners, post formats, and additional settings for your site's pages. Memberlite is responsive, clean and minimal.
 Version: 7.0
-Requires at least: 6.0
+Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
 License: GNU General Public License v2 or later

--- a/theme.json
+++ b/theme.json
@@ -709,6 +709,56 @@
 					"fontFamily": "\"Ubuntu\", sans-serif",
 					"name": "Ubuntu",
 					"slug": "ubuntu"
+				},
+				{
+					"fontFamily": "Arial, sans-serif",
+					"name": "Arial",
+					"slug": "arial"
+				},
+				{
+					"fontFamily": "Bookman, serif",
+					"name": "Bookman",
+					"slug": "bookman"
+				},
+				{
+					"fontFamily": "\"Courier New\", monospace",
+					"name": "Courier New",
+					"slug": "courier-new"
+				},
+				{
+					"fontFamily": "Garamond, serif",
+					"name": "Garamond",
+					"slug": "garamond"
+				},
+				{
+					"fontFamily": "Georgia, serif",
+					"name": "Georgia",
+					"slug": "georgia"
+				},
+				{
+					"fontFamily": "Helvetica, sans-serif",
+					"name": "Helvetica",
+					"slug": "helvetica"
+				},
+				{
+					"fontFamily": "Times, serif",
+					"name": "Times",
+					"slug": "times"
+				},
+				{
+					"fontFamily": "\"Times New Roman\", serif",
+					"name": "Times New Roman",
+					"slug": "times-new-roman"
+				},
+				{
+					"fontFamily": "\"Trebuchet MS\", sans-serif",
+					"name": "Trebuchet MS",
+					"slug": "trebuchet-ms"
+				},
+				{
+					"fontFamily": "Verdana, sans-serif",
+					"name": "Verdana",
+					"slug": "verdana"
 				}
 			],
 			"fontSizes": [
@@ -862,9 +912,9 @@
 			},
 			"core/image": {
 				"variations": {
-					"rounded" : {
+					"rounded": {
 						"border": {
-						"radius": "var(--wp--custom--border--radius)"
+							"radius": "var(--wp--custom--border--radius)"
 						}
 					}
 				},
@@ -972,7 +1022,7 @@
 					}
 				}
 			},
-			"core/comments-title":{
+			"core/comments-title": {
 				"spacing": {
 					"margin": {
 						"bottom": "var(--wp--preset--spacing--40)"
@@ -1155,8 +1205,8 @@
 				},
 				":focus": {
 					"outline": {
-					"color": "var(--wp--preset--color--body-text)",
-					"offset": "2px"
+						"color": "var(--wp--preset--color--body-text)",
+						"offset": "2px"
 					}
 				},
 				"spacing": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Refactors the font system so that theme.json is the single source of truth for available fonts, replacing the previously duplicated hardcoded font lists in PHP.

**Removed:**
- memberlite_load_local_webfonts() and its wp_head hook — WordPress 6.4+ natively outputs @font-face declarations from theme.json via <style class="wp-fonts-local">, making this function redundant
- Memberlite_Customize::get_google_fonts() and get_web_safe_fonts() — font lists were duplicated between these methods and theme.json

**Changed:**
- Memberlite_Customize::get_all_fonts() now reads available fonts directly from wp_get_global_settings() so the Customizer dropdown always reflects what is defined in theme.json
- memberlite_get_font() now returns a lowercase slug consistent with theme.json slug format; passing true as the second argument returns the display name via wp_get_global_settings()
- memberlite_filter_theme_json() uses a new memberlite_get_font_name_from_json_data() helper to look up font display names directly from the filter's own data, avoiding a circular call to wp_get_global_settings() that would cause infinite recursion
- Font defaults in inc/defaults.php updated to lowercase slugs (lato) to match theme.json format

**Added:**
- Web-safe fonts (Arial, Bookman, Courier New, Garamond, Georgia, Helvetica, Times, Times New Roman, Trebuchet MS, Verdana) added to theme.json as font family entries without fontFace — no file loading is emitted for them, but they appear in both the Customizer and block editor font pickers
- memberlite_get_font_name_from_json_data() helper for safe font name lookup inside the wp_theme_json_data_theme filter
- Migration 2026032601 in inc/updates.php to lowercase any existing memberlite_header_font / memberlite_body_font theme mods on upgrade
- Developer extensibility: Developers can now add custom fonts in one place by filtering wp_theme_json_data_theme. Fonts added there automatically appear in the Customizer dropdown, the block editor font picker, and have their @font-face output handled by WordPress — no PHP changes required.

## How to test the changes in this Pull Request:

1. Activate the theme on a fresh install. Verify the Customizer → Typography section shows all locally-hosted fonts and web-safe fonts in the heading and body font dropdowns.
2. Change the heading font and body font to different values. Save. Confirm the correct --memberlite-header-font and --memberlite-body-font CSS variables appear in the memberlite-customizer-css <style> tag in the page source, using the font display name (e.g. Playfair Display, not playfair-display).
3. Confirm there is no <style id="memberlite-webfonts-inline-css"> tag in the page source.
4. Confirm <style class="wp-fonts-local"> is present in the page source and contains @font-face declarations for the locally-hosted fonts.
5. Open the block editor and verify the selected heading and body fonts are active and the font picker lists all available fonts.
6. On an existing install with previously saved font theme mods (e.g. Lato), trigger the update migration and confirm the stored values are lowercased and the correct font is still selected in the Customizer.
7. In a child theme, add a custom font via wp_theme_json_data_theme filter and confirm it appears in the Customizer dropdown without any other PHP changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* REFACTOR: Update so `theme.json` is the one true source for fonts in Memberlite Customizer and Editor.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
