### PR TITLE
Add min width to sub-menus & adjust background colors on HTML elements

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,7 +4,7 @@
  *
  * @package Memberlite
  */
-define( 'MEMBERLITE_VERSION', '7.0.2' );
+define( 'MEMBERLITE_VERSION', '7.0.3' );
 define( 'MEMBERLITE_URL', get_template_directory_uri() );
 define( 'MEMBERLITE_DIR', get_template_directory() );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kimannwall, strangerstudios
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 7.0.2
+Stable tag: 7.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, left-sidebar, right-sidebar, flexible-header, custom-background, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, full-width-template, theme-options, threaded-comments, translation-ready, e-commerce
@@ -93,7 +93,7 @@ Memberlite includes formatting for use with:
 == Changelog ==
 
 = 7.0.2 - 2026-04-02 =
-* BUG FIX: Fixed issue in v7.0.1 that incremented theme.json version and should not have. 
+* BUG FIX: Fixed issue in v7.0.1 that incremented theme.json version and should not have.
 
 = 7.0.1 - 2026-04-02 =
 * ENHANCEMENT: Adjusted widget and secondary area styles to better balance theme presets and customizer flexibility. #238 (@RachelRVasquez)

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,8 @@ Memberlite includes formatting for use with:
 
 == Changelog ==
 
+= 7.0.3 - TBD =
+
 = 7.0.2 - 2026-04-02 =
 * BUG FIX: Fixed issue in v7.0.1 that incremented theme.json version and should not have.
 

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -222,7 +222,10 @@ cite {
 
 blockquote {
 	margin: var(--wp--preset--spacing--20) 0;
-	background-color: color-mix(in srgb, var(--memberlite-color-text) 7%, transparent);
+	background-color: light-dark(
+		color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
+		color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
+	);
 	padding: var(--wp--preset--spacing--20);
 
 	> :first-child {
@@ -240,7 +243,10 @@ address {
 }
 
 pre {
-	background-color: light-dark(color-mix(in srgb, var(--memberlite-color-text) 1%, transparent), color-mix(in srgb, var(--memberlite-color-text) 10%, transparent));
+	background-color: light-dark(
+			color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
+			color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
+	);
 	font-family: "Courier 10 Pitch", Courier, monospace;
 	margin: var(--wp--preset--spacing--20) 0;
 	max-width: 100%;
@@ -256,7 +262,10 @@ code,
 kbd,
 tt,
 var {
-	background-color: light-dark(color-mix(in srgb, var(--memberlite-color-text) 7%, transparent), color-mix(in srgb, var(--memberlite-color-text) 20%, transparent));
+	background-color: light-dark(
+		color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
+		color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
+	);
 	color: light-dark($color-error-text, $color-error-bg);
 	font-family: "Courier 10 Pitch", Courier, monospace;
 	padding: 2px 4px;

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -263,8 +263,8 @@ kbd,
 tt,
 var {
 	background-color: light-dark(
-		color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
-		color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
+			color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
+			color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
 	);
 	color: light-dark($color-error-text, $color-error-bg);
 	font-family: "Courier 10 Pitch", Courier, monospace;

--- a/src/scss/components/_widgets.scss
+++ b/src/scss/components/_widgets.scss
@@ -21,8 +21,8 @@
 	// Widget base
 	.widget {
 		background-color: light-dark(
-			color-mix(in srgb, var(--wp--preset--color--base), black 2%),
-			color-mix(in srgb, var(--wp--preset--color--base), white 5%)
+			color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
+			color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
 		);
 		border-radius: var(--wp--custom--border--radius);
 		overflow: hidden;

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -147,10 +147,6 @@
 
 			ul.sub-menu a {
 				padding: calc(var(--wp--preset--spacing--10) / 2) var(--wp--preset--spacing--10);
-
-				@include breakpoint(tablet) {
-					max-width: 210px;
-				}
 			}
 		}
 
@@ -375,8 +371,8 @@
 				top: 100%;
 				z-index: 99999;
 				margin: 0;
-				width: 100%;
-				min-width: max-content;
+				width: max-content;
+				max-width: 210px;
 				background-color: var(--memberlite-color-site-navigation-background);
 				box-shadow: 4px 12px 16px 0 rgba(0, 0, 0, 0.12);
 				text-align: left;

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -376,7 +376,7 @@
 				z-index: 99999;
 				margin: 0;
 				width: 100%;
-				min-width: 180px;
+				min-width: max-content;
 				background-color: var(--memberlite-color-site-navigation-background);
 				box-shadow: 4px 12px 16px 0 rgba(0, 0, 0, 0.12);
 				text-align: left;

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -376,6 +376,7 @@
 				z-index: 99999;
 				margin: 0;
 				width: 100%;
+				min-width: 180px;
 				background-color: var(--memberlite-color-site-navigation-background);
 				box-shadow: 4px 12px 16px 0 rgba(0, 0, 0, 0.12);
 				text-align: left;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://www.paidmembershipspro.com/
 Author: Stranger Studios
 Author URI: https://www.strangerstudios.com
 Description: Memberlite is the ideal theme for your membership site - packed with integration for top plugins including Paid Memberships Pro and LifterLMS. It's fully customizable with your logo, colors, fonts, custom sidebars and more global layout settings. Extend the site appearance further with icons, masthead banners, post formats, and additional settings for your site's pages. Memberlite is responsive, clean and minimal.
-Version: 7.0.2
+Version: 7.0.3
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Bug: Submenu width was too short when parent links were short and child menu items were long words
- Enhancement: Updated backgrounds to certain elements for consistency. (pre, blockquote, widget cards)

Also updated the version numbers across the theme to 7.0.3. No changelog yet. Version subject to change.

### How to test the changes in this Pull Request:

1. Check out this branch. Run `npm run build:css`
2. [View this page on your local](https://memberlite.pmproplugin.com/markup-html-tags-and-formatting/) or create something similar so you can see the affected html elements/blocks. Background colors should be visible, but text should remain readable. All background colors should match.
3. Refer to our "Bug: Sub-menu width needs a min width" ticket for details. Update an existing header menu to replicate and confirm the issue is resolved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updates Memberlite theme styling to improve dropdown submenu usability and make various “card/background” surfaces more visually consistent, while bumping the theme version to 7.0.3.
