### PR TITLE
No longer showing "legacy" in dropdown if there are footer choices available; link to manage footers from editor template settings sidebar

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1107,12 +1107,23 @@ if ( class_exists( 'WP_Customize_Control' ) ) {
 }
 
 /**
- * Active callback: show legacy footer controls only when the default footer is set to legacy (0).
+ * Active callback: show legacy footer controls only when no CPT footers exist and the default
+ * footer slug is unset (0). On new installs with generated footers, '0' is the uninitialized
+ * default — not a deliberate legacy choice — so we suppress these controls when CPT footers exist.
  *
  * @since 7.0
  */
 function memberlite_is_legacy_footer_active(): bool {
-	return '0' === get_theme_mod( 'memberlite_default_footer_slug', '0' );
+	if ( '0' !== get_theme_mod( 'memberlite_default_footer_slug', '0' ) ) {
+		return false;
+	}
+	$footer_posts = get_posts( array(
+		'post_type'      => 'memberlite_footer',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+	) );
+	return empty( $footer_posts );
 }
 
 // Setup the Theme Customizer settings and controls...

--- a/inc/editor-settings.php
+++ b/inc/editor-settings.php
@@ -95,6 +95,7 @@ function memberlite_enqueue_custom_editor_assets(): void {
 		array(
 			'showPrevNextSinglePages' => get_theme_mod( 'memberlite_page_nav', true ),
 			'footerVariations'        => memberlite_get_footer_variations(),
+			'manageFootersUrl'        => admin_url( 'edit.php?post_type=memberlite_footer' ),
 		)
 	);
 }

--- a/inc/variations.php
+++ b/inc/variations.php
@@ -74,7 +74,9 @@ function memberlite_render_footer_variation( $post_name ) {
  * @return array
  */
 function memberlite_get_footer_variations( string $default_label = '' ): array {
-	if ( '' === $default_label ) {
+	$is_legacy_slot = '' === $default_label;
+
+	if ( $is_legacy_slot ) {
 		$default_label = __( '— Use Legacy Footer —', 'memberlite' );
 	}
 
@@ -86,9 +88,13 @@ function memberlite_get_footer_variations( string $default_label = '' ): array {
 		'order'          => 'ASC',
 	) );
 
-	$footer_choices = array(
-		'0' => $default_label,
-	);
+	$footer_choices = array();
+
+	// Include the '0' (legacy footer) option only when no CPT footers exist.
+	// Context-specific selects always include '0' since it means "use the global default footer."
+	if ( ! $is_legacy_slot || empty( $footer_posts ) ) {
+		$footer_choices['0'] = $default_label;
+	}
 
 	if ( ! empty( $footer_posts ) ) {
 		foreach ( $footer_posts as $footer_post ) {

--- a/src/editor/custom-settings.js
+++ b/src/editor/custom-settings.js
@@ -1,7 +1,7 @@
 import {__} from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
-import { ToggleControl, SelectControl } from '@wordpress/components';
+import { ToggleControl, SelectControl, ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { SVG } from '@wordpress/primitives';
@@ -50,6 +50,7 @@ const MemberliteCustomSettings = () => {
 					setMeta( { ...meta, _memberlite_hide_header: value } );
 				} }
 			/>
+			<div style={{ marginTop: '24px' }} />
 			<ToggleControl
 				label={__('Hide Footer', textDomain)}
 				checked={ hideFooterValue }
@@ -58,23 +59,32 @@ const MemberliteCustomSettings = () => {
 				} }
 			/>
 			{ showPrevNextGlobally && (
-				<ToggleControl
-					label={__('Hide Prev/Next Page Navigation', textDomain)}
-					checked={ hidePageNavValue }
-					onChange={ ( value ) => {
-						setMeta( { ...meta, _memberlite_hide_page_nav: value } );
-					} }
-				/>
+				<>
+					<div style={{ marginTop: '24px' }} />
+					<ToggleControl
+						label={__('Hide Prev/Next Page Navigation', textDomain)}
+						checked={ hidePageNavValue }
+						onChange={ ( value ) => {
+							setMeta( { ...meta, _memberlite_hide_page_nav: value } );
+						} }
+					/>
+				</>
 			)}
 			{ ! hideFooterValue && (
-				<SelectControl
-					label={ __( 'Override Footer Variation', textDomain ) }
-					value={ footerOverrideValue }
-					options={ footerOptions }
-					onChange={ ( value ) => {
-						setMeta( { ...meta, _memberlite_footer_override: value } );
-					} }
-				/>
+				<>
+					<div style={{ marginTop: '24px' }} />
+					<SelectControl
+						label={ __( 'Override Footer Variation', textDomain ) }
+						value={ footerOverrideValue }
+						options={ footerOptions }
+						onChange={ ( value ) => {
+							setMeta( { ...meta, _memberlite_footer_override: value } );
+						} }
+					/>
+					<ExternalLink href={ window.memberliteEditorData.manageFootersUrl }>
+						{ __( 'Manage Footers', textDomain ) }
+					</ExternalLink>
+				</>
 			)}
 		</PluginDocumentSettingPanel>
 	);

--- a/src/scss/structure/_footer.scss
+++ b/src/scss/structure/_footer.scss
@@ -148,32 +148,6 @@
 }
 
 // -----------------------------------------------------------------------------
-// Site Footer — Variation 01
-// -----------------------------------------------------------------------------
-
-.footer-variation-01 .memberlite-footer-column-wrap {
-	@include breakpoint(mobile) {
-		flex-wrap: wrap;
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Site Footer — Variation 02
-// -----------------------------------------------------------------------------
-
-.footer-variation-02 {
-	.wp-block-navigation__container {
-		gap: var(--wp--preset--spacing--10);
-	}
-
-	.memberlite-footer-justify-center {
-		@include breakpoint(mobile) {
-			justify-content: center;
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
 // Floating Back to Top
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removing legacy option from dropdowns if modern CPTs are available. Rachel is handling "show legacy if they delete them all" in a separate PR.

Also adds a link to Manage Footers from the Template Settings page editor panel.

Also removing unnecessary CSS overrides for variations current state.
