### PR TITLE
Starting work for header variations, custom blocks needed, and three variations

### DIFF
--- a/components/header/header-mobile-row.php
+++ b/components/header/header-mobile-row.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mobile branding row for CPT-based header variations.
+ *
+ * Displays the site logo, site title, and mobile menu toggle button.
+ * Hidden on tablet and above via CSS (.site-header-mobile-row).
+ *
+ * @package Memberlite
+ */
+?>
+<div class="row site-header-mobile-row">
+	<div class="site-branding columns">
+		<?php memberlite_the_custom_logo(); ?>
+		<div class="site-identity">
+			<?php echo memberlite_output_site_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<span class="site-description"><?php bloginfo( 'description' ); ?></span>
+		</div>
+	</div>
+	<?php if ( is_active_sidebar( 'sidebar-5' ) || has_nav_menu( 'primary' ) ) { ?>
+		<div class="mobile-navigation-bar">
+			<button id="expand-mobile-nav" aria-haspopup="dialog" class="menu-toggle" aria-controls="mobile-navigation" aria-expanded="false">
+				<i class="fa fa-bars" aria-hidden="true"></i>
+				<span class="screen-reader-text">
+					<?php esc_html_e( 'Open mobile menu', 'memberlite' ); ?>
+				</span>
+			</button>
+		</div>
+	<?php } ?>
+</div>

--- a/functions.php
+++ b/functions.php
@@ -473,7 +473,7 @@ function memberlite_menus( $items, $args ) {
 	// is this the primary menu location or a replaced menu using pmpro-nav-menus plugin
 	if ( $args->theme_location == 'primary' || ( substr( $args->theme_location, -strlen( '-primary' ) ) === '-primary' ) ) {
 		$nav_menu_search = get_theme_mod( 'nav_menu_search', false );
-		if ( ! empty( $nav_menu_search ) ) {
+		if ( ! empty( $nav_menu_search ) && memberlite_is_legacy_header_active() ) {
 			$items .= '<li class="menu-item-search">' . get_search_form( false ) . '</li>';
 		}
 	}
@@ -591,6 +591,9 @@ require_once get_template_directory() . '/inc/template-tags.php';
 
 /* Custom theme variations code. */
 require_once get_template_directory() . '/inc/variations.php';
+
+/* Custom blocks. */
+require_once get_template_directory() . '/inc/blocks.php';
 
 /* Custom widgets that act independently of the theme templates. */
 require_once get_template_directory() . '/inc/widgets.php';

--- a/functions.php
+++ b/functions.php
@@ -474,7 +474,7 @@ function memberlite_menus( $items, $args ) {
 	// is this the primary menu location or a replaced menu using pmpro-nav-menus plugin
 	if ( $args->theme_location == 'primary' || ( substr( $args->theme_location, -strlen( '-primary' ) ) === '-primary' ) ) {
 		$nav_menu_search = get_theme_mod( 'nav_menu_search', false );
-		if ( ! empty( $nav_menu_search ) && memberlite_is_legacy_header_active() ) {
+		if ( ! empty( $nav_menu_search ) && memberlite_is_default_header_active() ) {
 			$items .= '<li class="menu-item-search">' . get_search_form( false ) . '</li>';
 		}
 	}

--- a/header.php
+++ b/header.php
@@ -28,15 +28,22 @@
 		<?php do_action( 'memberlite_before_site_header' ); ?>
 
 		<?php
-		$header_variation = get_theme_mod( 'memberlite_header_variation' );
-		$is_default       = empty( $header_variation ) || 'default' === $header_variation;
-		$header_class     = $is_default ? 'site-header-default' : 'site-header-' . $header_variation;
+		$header_post_name = memberlite_get_current_header_post_name();
+		$is_legacy_header = memberlite_is_legacy_header_active();
+		$header_class     = $is_legacy_header ? 'site-header-default' : 'site-header-' . esc_attr( $header_post_name );
 		?>
 		<header class="site-header <?php echo esc_attr( $header_class ); ?>" role="banner">
-			<?php if ( $is_default ) {
+			<?php if ( $is_legacy_header ) {
 				get_template_part( 'components/header/variation', 'default' );
 			} else {
-				get_template_part( 'components/header/variation', $header_variation );
+				get_template_part( 'components/header/header', 'mobile-row' );
+				?>
+				<div class="site-header-variation">
+					<?php memberlite_render_header_variation( $header_post_name ); ?>
+				</div>
+				<?php
+				get_template_part( 'components/header/header', 'mobile-menu' );
+				memberlite_the_header_edit_link( $header_post_name );
 			} ?>
 		</header><!-- #masthead -->
 	<?php } // End if memberlite_hide_page_header is false ?>

--- a/header.php
+++ b/header.php
@@ -28,18 +28,17 @@
 		<?php do_action( 'memberlite_before_site_header' ); ?>
 
 		<?php
-		$header_post_name        = memberlite_get_current_header_post_name();
-		$header_post_name_exists = ! empty( $header_post_name ) && '0' !== $header_post_name;
-		$header_class            = 'site-header';
+		$header_post_name = memberlite_get_current_header_post_name();
+		$header_class     = 'site-header';
 
-		if ( $header_post_name_exists ) {
+		if ( ! memberlite_is_default_header_active() ) {
 			$header_class .= ' site-header-' . sanitize_html_class( $header_post_name );
 		} else {
 			$header_class .= ' site-header-default';
 		}
 		?>
 		<header class="<?php echo esc_attr( $header_class ); ?>" role="banner">
-			<?php if ( ! $header_post_name_exists ) {
+			<?php if ( memberlite_is_default_header_active() ) {
 				get_template_part( 'components/header/variation', 'default' );
 			} else {
 				get_template_part( 'components/header/header', 'mobile-row' );

--- a/header.php
+++ b/header.php
@@ -28,24 +28,34 @@
 		<?php do_action( 'memberlite_before_site_header' ); ?>
 
 		<?php
-		$header_post_name = memberlite_get_current_header_post_name();
-		$is_legacy_header = memberlite_is_legacy_header_active();
-		$header_class     = $is_legacy_header ? 'site-header-default' : 'site-header-' . esc_attr( $header_post_name );
+		$header_post_name        = memberlite_get_current_header_post_name();
+		$header_post_name_exists = ! empty( $header_post_name ) && '0' !== $header_post_name;
+		$header_class            = 'site-header';
+
+		if ( $header_post_name_exists ) {
+			$header_class .= ' site-header-' . sanitize_html_class( $header_post_name );
+		} else {
+			$header_class .= ' site-header-default';
+		}
 		?>
-		<header class="site-header <?php echo esc_attr( $header_class ); ?>" role="banner">
-			<?php if ( $is_legacy_header ) {
+		<header class="<?php echo esc_attr( $header_class ); ?>" role="banner">
+			<?php if ( ! $header_post_name_exists ) {
 				get_template_part( 'components/header/variation', 'default' );
 			} else {
 				get_template_part( 'components/header/header', 'mobile-row' );
 				?>
 				<div class="site-header-variation">
-					<?php memberlite_render_header_variation( $header_post_name ); ?>
+					<?php
+					if ( ! memberlite_render_header_variation( $header_post_name ) ) {
+						get_template_part( 'components/header/variation', 'default' );
+					}
+					?>
 				</div>
 				<?php
 				get_template_part( 'components/header/header', 'mobile-menu' );
-				memberlite_the_header_edit_link( $header_post_name );
 			} ?>
 		</header><!-- #masthead -->
+		<?php memberlite_the_header_edit_link( $header_post_name ); ?>
 	<?php } // End if memberlite_hide_page_header is false ?>
 
 	<?php do_action( 'memberlite_before_content' ); ?>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -27,6 +27,8 @@ function memberlite_add_pages() {
 	add_submenu_page( 'memberlite-dashboard', __( 'Tools', 'memberlite' ), __( 'Tools', 'memberlite' ), 'edit_theme_options', 'memberlite-tools', 'memberlite_tools' );
 
 	add_submenu_page( 'memberlite-dashboard', __( 'Footers', 'memberlite' ), __( 'Footers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_footer' );
+
+	add_submenu_page( 'memberlite-dashboard', __( 'Headers', 'memberlite' ), __( 'Headers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_header' );
 }
 add_action( 'admin_menu', 'memberlite_add_pages' );
 
@@ -65,6 +67,42 @@ function memberlite_footer_cpt_submenu_highlight( $submenu_file ) {
 	return $submenu_file;
 }
 add_filter( 'submenu_file', 'memberlite_footer_cpt_submenu_highlight' );
+
+/**
+ * Keep the Memberlite menu and Headers submenu item highlighted when viewing the list table or editing a single memberlite_header post.
+ *
+ * @since TBD
+ * @param mixed|string $parent_file The parent file for the Memberlite menu.
+ * @return string $parent_file The parent file for the Memberlite menu.
+ */
+function memberlite_header_cpt_menu_highlight( $parent_file ) {
+	global $post_type;
+
+	if ( 'memberlite_header' === $post_type ) {
+		return 'memberlite-dashboard';
+	}
+
+	return $parent_file;
+}
+add_filter( 'parent_file', 'memberlite_header_cpt_menu_highlight' );
+
+/**
+ * Keep the Memberlite Headers submenu item highlighted when viewing the list table or editing a single memberlite_header post.
+ *
+ * @since TBD
+ * @param mixed|string $submenu_file The submenu file for the Memberlite menu.
+ * @return string $submenu_file The submenu file for the Memberlite menu.
+ */
+function memberlite_header_cpt_submenu_highlight( $submenu_file ) {
+	global $post_type;
+
+	if ( 'memberlite_header' === $post_type ) {
+		return 'edit.php?post_type=memberlite_header';
+	}
+
+	return $submenu_file;
+}
+add_filter( 'submenu_file', 'memberlite_header_cpt_submenu_highlight' );
 
 /**
  * Show an action button for the specified plugin

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -20,15 +20,15 @@ function memberlite_add_pages() {
 	// Memberlite admin subpages.
 	add_submenu_page( 'memberlite-dashboard', __( 'Dashboard', 'memberlite' ), __( 'Dashboard', 'memberlite' ), 'edit_theme_options', 'memberlite-dashboard', 'memberlite_dashboard' );
 
+	add_submenu_page( 'memberlite-dashboard', __( 'Headers', 'memberlite' ), __( 'Headers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_header' );
+
+	add_submenu_page( 'memberlite-dashboard', __( 'Footers', 'memberlite' ), __( 'Footers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_footer' );
+
 	add_submenu_page( 'memberlite-dashboard', __( 'Custom Menus', 'memberlite' ), __( 'Custom Menus', 'memberlite' ), 'edit_theme_options', 'memberlite-custom-menus', 'memberlite_custom_menus' );
 
 	add_submenu_page( 'memberlite-dashboard', __( 'Custom Sidebars', 'memberlite' ), __( 'Custom Sidebars', 'memberlite' ), 'edit_theme_options', 'memberlite-custom-sidebars', 'memberlite_custom_sidebars' );
 
 	add_submenu_page( 'memberlite-dashboard', __( 'Tools', 'memberlite' ), __( 'Tools', 'memberlite' ), 'edit_theme_options', 'memberlite-tools', 'memberlite_tools' );
-
-	add_submenu_page( 'memberlite-dashboard', __( 'Footers', 'memberlite' ), __( 'Footers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_footer' );
-
-	add_submenu_page( 'memberlite-dashboard', __( 'Headers', 'memberlite' ), __( 'Headers', 'memberlite' ), 'edit_theme_options', 'edit.php?post_type=memberlite_header' );
 }
 add_action( 'admin_menu', 'memberlite_add_pages' );
 

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Register custom blocks for Memberlite.
+ *
+ * @package Memberlite
+ * @since TBD
+ */
+
+/**
+ * Register a block category for Memberlite blocks.
+ *
+ * @since TBD
+ * @param array $categories Existing block categories.
+ * @return array
+ */
+function memberlite_register_block_categories( array $categories ): array {
+	return array_merge(
+		$categories,
+		array(
+			array(
+				'slug'  => 'memberlite',
+				'title' => __( 'Memberlite', 'memberlite' ),
+				'icon'  => null,
+			),
+		)
+	);
+}
+add_filter( 'block_categories_all', 'memberlite_register_block_categories' );
+
+/**
+ * Register custom Memberlite blocks.
+ *
+ * Each block's editor script handle is registered first so that
+ * register_block_type() (which reads the named handle from block.json)
+ * can resolve it correctly.
+ *
+ * @since TBD
+ * @return void
+ */
+function memberlite_register_blocks(): void {
+	// Nav Menu block.
+	wp_register_script(
+		'memberlite-block-nav-menu-editor',
+		get_template_directory_uri() . '/build/blocks/nav-menu/index.js',
+		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+		MEMBERLITE_VERSION,
+		true
+	);
+	register_block_type( get_template_directory() . '/build/blocks/nav-menu' );
+
+	// Member Info block.
+	wp_register_script(
+		'memberlite-block-member-info-editor',
+		get_template_directory_uri() . '/build/blocks/member-info/index.js',
+		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+		MEMBERLITE_VERSION,
+		true
+	);
+	register_block_type( get_template_directory() . '/build/blocks/member-info' );
+}
+add_action( 'init', 'memberlite_register_blocks' );

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -60,3 +60,61 @@ function memberlite_register_footer_cpt(): void {
 	);
 }
 add_action( 'init', 'memberlite_register_footer_cpt' );
+
+/**
+ * Register the memberlite_header CPT for header variations.
+ *
+ * Not public-facing; only accessible in the admin.
+ *
+ * @since TBD
+ * @return void
+ */
+function memberlite_register_header_cpt(): void {
+	$labels = array(
+		'name'               => __( 'Header Variations', 'memberlite' ),
+		'singular_name'      => __( 'Header Variation', 'memberlite' ),
+		'add_new'            => __( 'Add New Header Variation', 'memberlite' ),
+		'add_new_item'       => __( 'Add New Header Variation', 'memberlite' ),
+		'edit_item'          => __( 'Edit Header Variation', 'memberlite' ),
+		'new_item'           => __( 'New Header Variation', 'memberlite' ),
+		'view_item'          => __( 'View Header Variation', 'memberlite' ),
+		'search_items'       => __( 'Search Header Variations', 'memberlite' ),
+		'not_found'          => __( 'No header variations found.', 'memberlite' ),
+		'not_found_in_trash' => __( 'No header variations found in Trash.', 'memberlite' ),
+		'all_items'          => __( 'All Header Variations', 'memberlite' ),
+		'menu_name'          => __( 'Header Variations', 'memberlite' ),
+	);
+
+	register_post_type(
+		'memberlite_header',
+		array(
+			'labels'              => $labels,
+			'public'              => false,
+			'publicly_queryable'  => false,
+			'show_ui'             => true,
+			'show_in_menu'        => false,  // placed under Memberlite menu manually
+			'show_in_rest'        => true,   // required for block editor support
+			'supports'            => array( 'title', 'editor', 'revisions' ),
+			'rewrite'             => false,
+			'query_var'           => false,
+			'has_archive'         => false,
+			'capabilities'        => array(
+				'read_post'              => 'edit_theme_options',
+				'read_private_posts'     => 'edit_theme_options',
+				'edit_post'              => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
+				'edit_others_posts'      => 'edit_theme_options',
+				'edit_private_posts'     => 'edit_theme_options',
+				'edit_published_posts'   => 'edit_theme_options',
+				'publish_posts'          => 'edit_theme_options',
+				'delete_post'            => 'edit_theme_options',
+				'delete_posts'           => 'edit_theme_options',
+				'delete_private_posts'   => 'edit_theme_options',
+				'delete_published_posts' => 'edit_theme_options',
+				'delete_others_posts'    => 'edit_theme_options',
+				'create_posts'           => 'edit_theme_options',
+			),
+		)
+	);
+}
+add_action( 'init', 'memberlite_register_header_cpt' );

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -62,6 +62,41 @@ function memberlite_register_header_cpt(): void {
 add_action( 'init', 'memberlite_register_header_cpt' );
 
 /**
+ * Auto-generate a title and slug for memberlite_header posts saved without one.
+ *
+ * Assigns a name like "Header 123" (using the post ID) and a matching slug,
+ * replacing the bare numeric slug WordPress assigns to untitled posts.
+ *
+ * @since TBD
+ * @param int     $post_id The post ID.
+ * @param WP_Post $post    The post object.
+ * @return void
+ */
+function memberlite_header_auto_title( int $post_id, WP_Post $post ): void {
+	if ( wp_is_post_revision( $post_id ) || $post->post_status === 'auto-draft' ) {
+		return;
+	}
+
+	if ( ! empty( $post->post_title ) ) {
+		return;
+	}
+
+	$auto_title = sprintf( __( 'Header %d', 'memberlite' ), $post_id );
+	$auto_slug  = 'header-' . $post_id;
+
+	remove_action( 'save_post_memberlite_header', 'memberlite_header_auto_title', 10 );
+
+	wp_update_post( array(
+		'ID'         => $post_id,
+		'post_title' => $auto_title,
+		'post_name'  => $auto_slug,
+	) );
+
+	add_action( 'save_post_memberlite_header', 'memberlite_header_auto_title', 10, 2 );
+}
+add_action( 'save_post_memberlite_header', 'memberlite_header_auto_title', 10, 2 );
+
+/**
  * Register the memberlite_footer CPT for footer variations.
  *
  * Not public-facing; only accessible in the admin.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -357,12 +357,32 @@ class Memberlite_Customize {
 	 * @return void
 	 */
 	public static function set_customizer_header_settings( WP_Customize_Manager $wp_customize ) {
+		// HEADER: Variation Settings Heading ===
+		self::add_memberlite_heading( $wp_customize, 'memberlite_pattern_header_heading', __( 'Variation Settings', 'memberlite' ), 'memberlite_header_options' );
+
+		// HEADER: Manage Headers link ==========
+		self::add_memberlite_link_control( $wp_customize, 'memberlite_manage_headers_link', __( 'Manage Headers', 'memberlite' ), 'memberlite_header_options', admin_url( 'edit.php?post_type=memberlite_header' ) );
+
+		// HEADER: Default Header ===============
+		self::add_memberlite_setting_control( $wp_customize, 'memberlite_default_header_slug', __( 'Default Header', 'memberlite' ), 'memberlite_header_options', array(
+			'type'              => 'select',
+			'sanitize_callback' => 'sanitize_key',
+			'choices'           => memberlite_get_header_variations(),
+			'default'           => '0',
+			'description'       => __( 'Choose which header pattern to display across the site.', 'memberlite' ),
+		) );
+
+		// HEADER: Legacy Settings Heading ======
+		self::add_memberlite_heading( $wp_customize, 'memberlite_legacy_header_heading', __( 'Legacy Settings', 'memberlite' ), 'memberlite_header_options', array(
+			'active_callback' => 'memberlite_is_legacy_header_active',
+		) );
+
 		// HEADER: Columns Ratio ================
 		self::add_memberlite_setting_control( $wp_customize, 'columns_ratio_header', __( 'Columns Ratio', 'memberlite' ), 'memberlite_header_options', array(
-			'type'        => 'select',
-			'transport'   => 'refresh',
-			'description' => __( 'Controls how the left and right sections of your header are sized. For example, "4-8" makes the left side narrower and the right side wider.', 'memberlite' ),
-			'choices'     => array(
+			'type'            => 'select',
+			'transport'       => 'refresh',
+			'description'     => __( 'Controls how the left and right sections of your header are sized. For example, "4-8" makes the left side narrower and the right side wider.', 'memberlite' ),
+			'choices'         => array(
 				'1-11' => '1x11',
 				'2-10' => '2x10',
 				'3-9'  => '3x9',
@@ -375,21 +395,26 @@ class Memberlite_Customize {
 				'10-2' => '10x2',
 				'11-1' => '11x1',
 			),
+			'active_callback' => 'memberlite_is_legacy_header_active',
 		) );
 
 		// HEADER: Other Settings Heading =======
-		self::add_memberlite_heading( $wp_customize, 'memberlite_header_heading', __( 'Other Settings', 'memberlite' ), 'memberlite_header_options' );
+		self::add_memberlite_heading( $wp_customize, 'memberlite_header_heading', __( 'Other Settings', 'memberlite' ), 'memberlite_header_options', array(
+			'active_callback' => 'memberlite_is_legacy_header_active',
+		) );
 
 		// HEADER: Show Login/Member Info =======
 		self::add_memberlite_setting_control( $wp_customize, 'meta_login', __( 'Show Login/Member Info in Header', 'memberlite' ), 'memberlite_header_options', array(
 			'type'              => 'checkbox',
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
+			'active_callback'   => 'memberlite_is_legacy_header_active',
 		) );
 
 		// HEADER: Show search form =============
 		self::add_memberlite_setting_control( $wp_customize, 'nav_menu_search', __( 'Show Search Form After Main Nav', 'memberlite' ), 'memberlite_header_options', array(
 			'type'              => 'checkbox',
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
+			'active_callback'   => 'memberlite_is_legacy_header_active',
 		) );
 
 		// HEADER: Enable sticky header =========
@@ -397,6 +422,7 @@ class Memberlite_Customize {
 			'type'              => 'checkbox',
 			'description'       => __( 'On scroll, the header menu will stick to the top of the screen.', 'memberlite' ),
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
+			'active_callback'   => 'memberlite_is_legacy_header_active',
 		) );
 	}
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -372,9 +372,9 @@ class Memberlite_Customize {
 			'description'       => __( 'Choose which header pattern to display across the site.', 'memberlite' ),
 		) );
 
-		// HEADER: Legacy Settings Heading ======
-		self::add_memberlite_heading( $wp_customize, 'memberlite_legacy_header_heading', __( 'Legacy Settings', 'memberlite' ), 'memberlite_header_options', array(
-			'active_callback' => 'memberlite_is_legacy_header_active',
+		// HEADER: Default Header Settings Heading ======
+		self::add_memberlite_heading( $wp_customize, 'memberlite_default_header_heading', __( 'Default Header Settings', 'memberlite' ), 'memberlite_header_options', array(
+			'active_callback' => 'memberlite_is_default_header_active',
 		) );
 
 		// HEADER: Columns Ratio ================
@@ -395,26 +395,26 @@ class Memberlite_Customize {
 				'10-2' => '10x2',
 				'11-1' => '11x1',
 			),
-			'active_callback' => 'memberlite_is_legacy_header_active',
+			'active_callback' => 'memberlite_is_default_header_active',
 		) );
 
 		// HEADER: Other Settings Heading =======
 		self::add_memberlite_heading( $wp_customize, 'memberlite_header_heading', __( 'Other Settings', 'memberlite' ), 'memberlite_header_options', array(
-			'active_callback' => 'memberlite_is_legacy_header_active',
+			'active_callback' => 'memberlite_is_default_header_active',
 		) );
 
 		// HEADER: Show Login/Member Info =======
 		self::add_memberlite_setting_control( $wp_customize, 'meta_login', __( 'Show Login/Member Info in Header', 'memberlite' ), 'memberlite_header_options', array(
 			'type'              => 'checkbox',
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
-			'active_callback'   => 'memberlite_is_legacy_header_active',
+			'active_callback'   => 'memberlite_is_default_header_active',
 		) );
 
 		// HEADER: Show search form =============
 		self::add_memberlite_setting_control( $wp_customize, 'nav_menu_search', __( 'Show Search Form After Main Nav', 'memberlite' ), 'memberlite_header_options', array(
 			'type'              => 'checkbox',
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
-			'active_callback'   => 'memberlite_is_legacy_header_active',
+			'active_callback'   => 'memberlite_is_default_header_active',
 		) );
 
 		// HEADER: Enable sticky header =========
@@ -422,7 +422,7 @@ class Memberlite_Customize {
 			'type'              => 'checkbox',
 			'description'       => __( 'On scroll, the header menu will stick to the top of the screen.', 'memberlite' ),
 			'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
-			'active_callback'   => 'memberlite_is_legacy_header_active',
+			'active_callback'   => 'memberlite_is_default_header_active',
 		) );
 	}
 

--- a/inc/patterns.php
+++ b/inc/patterns.php
@@ -20,6 +20,7 @@ function memberlite_register_pattern_categories(): void {
 		'memberlite-courses'      => __( 'Memberlite - Courses', 'memberlite' ),
 		'memberlite-cta'          => __( 'Memberlite - Call to Action', 'memberlite' ),
 		'memberlite-footer'       => __( 'Memberlite - Footer Variations', 'memberlite' ),
+		'memberlite-header'       => __( 'Memberlite - Header Variations', 'memberlite' ),
 		'memberlite-media'        => __( 'Memberlite - Media', 'memberlite' ),
 		'memberlite-team'         => __( 'Memberlite - Team', 'memberlite' ),
 		'memberlite-testimonials' => __( 'Memberlite - Testimonials', 'memberlite' ),

--- a/inc/variations.php
+++ b/inc/variations.php
@@ -138,7 +138,7 @@ function memberlite_get_footer_variations(): array {
 /**
  * Get the post_name of the current header variation.
  *
- * Returns '0' if no CPT header variation is selected (legacy header).
+ * Returns '0' if no CPT header variation is selected (default header).
  *
  * @since TBD
  * @return string
@@ -152,34 +152,36 @@ function memberlite_get_current_header_post_name(): string {
  * Render a header variation.
  *
  * Looks up the memberlite_header CPT post by post_name and renders its block
- * content. Does nothing if the post is not found; the legacy header fallback
- * is handled upstream in header.php.
+ * content. Returns true on success, false if the post was not found or is not
+ * published; the default header fallback is handled upstream in header.php.
  *
  * @since TBD
  * @param string $post_name The post_name of the memberlite_header post to render.
+ * @return bool True if the variation was rendered, false otherwise.
  */
-function memberlite_render_header_variation( string $post_name ): void {
-	if ( empty( $post_name ) || '0' === $post_name ) {
-		return;
+function memberlite_render_header_variation( string $post_name ): bool {
+	if ( ! empty( $post_name ) && '0' !== $post_name ) {
+		$header_post = get_page_by_path( $post_name, OBJECT, 'memberlite_header' );
+
+		if ( $header_post && 'publish' === $header_post->post_status ) {
+			echo do_shortcode( do_blocks( $header_post->post_content ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			return true;
+		}
 	}
 
-	$header_post = get_page_by_path( $post_name, OBJECT, 'memberlite_header' );
-
-	if ( $header_post ) {
-		echo do_shortcode( do_blocks( $header_post->post_content ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	}
+	return false;
 }
 
 /**
  * Get memberlite_header posts for variation options.
  *
  * @since TBD
- * @param string $default_label Optional label for the legacy option.
+ * @param string $default_label Optional label for the default option.
  * @return array
  */
 function memberlite_get_header_variations( string $default_label = '' ): array {
 	if ( '' === $default_label ) {
-		$default_label = __( '— Use Legacy Header —', 'memberlite' );
+		$default_label = __( '— Default —', 'memberlite' );
 	}
 
 	$header_posts = get_posts( array(
@@ -202,12 +204,12 @@ function memberlite_get_header_variations( string $default_label = '' ): array {
 }
 
 /**
- * Returns true when the active header variation is the legacy PHP-based header.
+ * Returns true when the active header variation is the default PHP-based header.
  *
  * @since TBD
  * @return bool
  */
-function memberlite_is_legacy_header_active(): bool {
+function memberlite_is_default_header_active(): bool {
 	$slug = get_theme_mod( 'memberlite_default_header_slug', '0' );
 	return empty( $slug ) || '0' === $slug;
 }
@@ -215,7 +217,7 @@ function memberlite_is_legacy_header_active(): bool {
 /**
  * Output an "Edit Header" link for users who can edit the current header post.
  *
- * Only renders for CPT-based headers (not the legacy header).
+ * Only renders for CPT-based headers (not the default header).
  *
  * @since TBD
  * @param string $post_name The post_name of the current header post.

--- a/inc/variations.php
+++ b/inc/variations.php
@@ -99,6 +99,125 @@ function memberlite_get_footer_variations( string $default_label = '' ): array {
 	return $footer_choices;
 }
 
+/*
+ * =========================================================================
+ * Header Variations
+ * =========================================================================
+ */
+
+/**
+ * Get the post_name of the current header variation.
+ *
+ * Returns '0' if no CPT header variation is selected (legacy header).
+ *
+ * @since TBD
+ * @return string
+ */
+function memberlite_get_current_header_post_name(): string {
+	$post_name = get_theme_mod( 'memberlite_default_header_slug', '0' );
+	return empty( $post_name ) ? '0' : $post_name;
+}
+
+/**
+ * Render a header variation.
+ *
+ * Looks up the memberlite_header CPT post by post_name and renders its block
+ * content. Does nothing if the post is not found; the legacy header fallback
+ * is handled upstream in header.php.
+ *
+ * @since TBD
+ * @param string $post_name The post_name of the memberlite_header post to render.
+ */
+function memberlite_render_header_variation( string $post_name ): void {
+	if ( empty( $post_name ) || '0' === $post_name ) {
+		return;
+	}
+
+	$header_post = get_page_by_path( $post_name, OBJECT, 'memberlite_header' );
+
+	if ( $header_post ) {
+		echo do_shortcode( do_blocks( $header_post->post_content ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+}
+
+/**
+ * Get memberlite_header posts for variation options.
+ *
+ * @since TBD
+ * @param string $default_label Optional label for the legacy option.
+ * @return array
+ */
+function memberlite_get_header_variations( string $default_label = '' ): array {
+	if ( '' === $default_label ) {
+		$default_label = __( '— Use Legacy Header —', 'memberlite' );
+	}
+
+	$header_posts = get_posts( array(
+		'post_type'      => 'memberlite_header',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+	) );
+
+	$header_choices = array(
+		'0' => $default_label,
+	);
+
+	foreach ( $header_posts as $header_post ) {
+		$header_choices[ $header_post->post_name ] = $header_post->post_title;
+	}
+
+	return $header_choices;
+}
+
+/**
+ * Returns true when the active header variation is the legacy PHP-based header.
+ *
+ * @since TBD
+ * @return bool
+ */
+function memberlite_is_legacy_header_active(): bool {
+	$slug = get_theme_mod( 'memberlite_default_header_slug', '0' );
+	return empty( $slug ) || '0' === $slug;
+}
+
+/**
+ * Output an "Edit Header" link for users who can edit the current header post.
+ *
+ * Only renders for CPT-based headers (not the legacy header).
+ *
+ * @since TBD
+ * @param string $post_name The post_name of the current header post.
+ */
+function memberlite_the_header_edit_link( string $post_name ): void {
+	if ( empty( $post_name ) || '0' === $post_name ) {
+		return;
+	}
+
+	$header_post = get_page_by_path( $post_name, OBJECT, 'memberlite_header' );
+
+	if ( ! $header_post || ! current_user_can( 'edit_post', $header_post->ID ) ) {
+		return;
+	}
+
+	$edit_url = get_edit_post_link( $header_post->ID );
+
+	if ( ! $edit_url ) {
+		return;
+	}
+
+	echo '<div class="memberlite-variation-part-edit-link">';
+	echo '<a href="' . esc_url( $edit_url ) . '">' . esc_html__( 'Edit Header', 'memberlite' ) . '</a>';
+	echo '</div>';
+}
+
+/*
+ * =========================================================================
+ * Footer Variations (edit links)
+ * =========================================================================
+ */
+
 /**
  * Output an "Edit Footer" link for users who can edit the current footer post.
  *

--- a/patterns/header-01.php
+++ b/patterns/header-01.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Title: Header: Two-Column Classic
+ * Slug: memberlite/header-01
+ * Description: Site branding on the left, member info on the right, with navigation below.
+ * Categories: memberlite-header, header
+ * Keywords: header, navigation, member, classic, two-column
+ * Block Types: core/post-content
+ * Post Types: memberlite_header
+ * @package WordPress
+ * @subpackage Memberlite
+ * @since TBD
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:column {"verticalAlignment":"top","width":"40%","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);flex-basis:40%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:site-logo {"width":120,"className":"is-style-default","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|10"}}}} /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:site-title {"level":0,"fontSize":"30"} /-->
+
+<!-- wp:site-tagline /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"60%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%"><!-- wp:group {"layout":{"type":"constrained","justifyContent":"right"}} -->
+<div class="wp-block-group"><!-- wp:memberlite/member-info /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:memberlite/nav-menu /-->
+
+<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search","buttonPosition":"no-button"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/patterns/header-02.php
+++ b/patterns/header-02.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Title: Header: Inline Logo + Navigation
+ * Slug: memberlite/header-02
+ * Description: Logo, navigation, and member info all on a single row.
+ * Categories: memberlite-header, header
+ * Keywords: header, navigation, member, inline, compact, single-row
+ * Block Types: core/post-content
+ * Post Types: memberlite_header
+ * @package WordPress
+ * @subpackage Memberlite
+ * @since TBD
+ */
+?>
+<!-- wp:group {"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|borders","width":"1px"}},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"0","right":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}}},"backgroundColor":"footer-widgets-background","textColor":"footer-widgets","fontSize":"16","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-footer-widgets-color has-footer-widgets-background-background-color has-text-color has-background has-link-color has-16-font-size" style="border-bottom-color:var(--wp--preset--color--borders);border-bottom-width:1px;padding-top:10px;padding-right:0;padding-bottom:10px;padding-left:0"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:social-links {"iconColor":"footer-widgets","iconColorValue":"#222222","size":"has-normal-icon-size","className":"has-icon-color is-style-logos-only","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<ul class="wp-block-social-links has-normal-icon-size has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /-->
+
+<!-- wp:social-link {"url":"#","service":"youtube"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:memberlite/member-info /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center" style="margin-bottom:0"><!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
+<div class="wp-block-group"><!-- wp:site-logo /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+<div class="wp-block-group"><!-- wp:site-title {"level":0} /-->
+
+<!-- wp:site-tagline /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"auto"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+<div class="wp-block-group"><!-- wp:memberlite/nav-menu {"menuLocation":"member"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/header-02.php
+++ b/patterns/header-02.php
@@ -30,7 +30,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center" style="margin-bottom:0"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
@@ -46,7 +46,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"auto"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-<div class="wp-block-group"><!-- wp:memberlite/nav-menu {"menuLocation":"member"} /--></div>
+<div class="wp-block-group"><!-- wp:memberlite/nav-menu {"menuLocation":"primary"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/patterns/header-03.php
+++ b/patterns/header-03.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Header: Centered Branding
+ * Slug: memberlite/header-03
+ * Description: Colored header bar with centered logo and site branding, social links, and centered navigation.
+ * Categories: memberlite-header, header
+ * Keywords: header, navigation, member, centered, stacked
+ * Block Types: core/post-content
+ * Post Types: memberlite_header
+ * @package WordPress
+ * @subpackage Memberlite
+ * @since TBD
+ */
+?>
+<!-- wp:group {"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|borders","width":"1px"}},"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}}},"backgroundColor":"footer-widgets-background","textColor":"footer-widgets","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-footer-widgets-color has-footer-widgets-background-background-color has-text-color has-background has-link-color" style="border-bottom-color:var(--wp--preset--color--borders);border-bottom-width:1px"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:site-logo {"width":140,"align":"center","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|10"}}}} /-->
+
+<!-- wp:site-title {"level":0,"textAlign":"center"} /-->
+
+<!-- wp:site-tagline {"textAlign":"center"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:social-links {"iconColor":"footer-widgets","iconColorValue":"#222222","size":"has-normal-icon-size","className":"has-icon-color is-style-logos-only","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<ul class="wp-block-social-links has-normal-icon-size has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /-->
+
+<!-- wp:social-link {"url":"#","service":"youtube"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:memberlite/nav-menu /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/src/blocks/member-info/block.json
+++ b/src/blocks/member-info/block.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "memberlite/member-info",
+    "version": "1.0.0",
+    "title": "Member Info",
+    "category": "memberlite",
+    "description": "Shows member login info, welcome message, and member navigation menus.",
+    "icon": "admin-users",
+    "supports": {
+        "html": false,
+        "reusable": false,
+        "lock": false
+    },
+    "attributes": {
+        "showWelcomeMessage": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "render": "file:./render.php",
+    "editorScript": "memberlite-block-member-info-editor",
+    "editorStyle": "file:./index.css",
+    "textdomain": "memberlite"
+}

--- a/src/blocks/member-info/editor.css
+++ b/src/blocks/member-info/editor.css
@@ -1,0 +1,10 @@
+/*
+ * Editor placeholder styles for the memberlite/member-info block.
+ */
+
+.wp-block-memberlite-member-info.memberlite-member-info-placeholder {
+	opacity: 0.75;
+	padding: 10px 14px;
+	text-align: center;
+	border: 2px dashed #c3c4c7;
+}

--- a/src/blocks/member-info/index.js
+++ b/src/blocks/member-info/index.js
@@ -1,0 +1,41 @@
+import './editor.css';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import metadata from './block.json';
+
+function Edit( { attributes, setAttributes } ) {
+	const { showWelcomeMessage } = attributes;
+	const blockProps = useBlockProps( {
+		className: 'memberlite-member-info-placeholder',
+	} );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Member Info Settings', 'memberlite' ) }>
+					<ToggleControl
+						label={ __( 'Show Welcome Message', 'memberlite' ) }
+						help={ __(
+							'Show "Welcome, [name]" for logged-in users.',
+							'memberlite'
+						) }
+						checked={ showWelcomeMessage }
+						onChange={ ( value ) =>
+							setAttributes( { showWelcomeMessage: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<strong>{ __( 'Member Info', 'memberlite' ) }</strong>
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/member-info/render.php
+++ b/src/blocks/member-info/render.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Server-side render for the memberlite/member-info block.
+ *
+ * Available variables:
+ *   $attributes  (array)          Block attributes.
+ *   $content     (string)         Inner block content (unused — no inner blocks).
+ *   $block       (WP_Block)       Block instance.
+ *
+ * Mirrors the logic of components/header/header-member-info.php but without
+ * the memberlite_is_meta_login_active() gate — the block is explicitly placed.
+ *
+ * @package Memberlite
+ * @since TBD
+ */
+
+global $current_user, $pmpro_pages;
+
+$show_welcome        = $attributes['showWelcomeMessage'] ?? true;
+
+$wrapper_attributes = get_block_wrapper_attributes();
+?>
+<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+<div id="meta-member">
+	<div class="meta-member-inner">
+		<?php if ( $current_user->ID ) { ?>
+			<?php if ( $show_welcome ) {
+				$get_account_url   = ! empty( $pmpro_pages ) ? pmpro_url( 'account' ) : admin_url( 'profile.php' );
+				$user_account_link = '<a href="' . esc_url( $get_account_url ) . '">' . esc_html( preg_replace( '/\@.*/', '', $current_user->display_name ) ) . '</a>';
+				?>
+				<span class="user">
+					<span aria-hidden="true" class="fa fa-user"></span>
+					<?php /* translators: a generated link to the user's account or profile page */
+					echo Memberlite_Customize::sanitize_text_with_links( sprintf( __( 'Welcome, %s', 'memberlite' ), $user_account_link ) ); // WPCS: xss ok.
+					?>
+				</span>
+			<?php } ?>
+			<?php
+			wp_nav_menu( array(
+				'theme_location'  => 'member',
+				'container'       => 'nav',
+				'container_id'    => 'member-navigation',
+				'container_class' => 'member-navigation',
+				'fallback_cb'     => 'memberlite_member_menu_cb',
+				'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				'walker'          => new Memberlite_Aria_Walker_Nav_Menu(),
+				'depth'           => 2,
+			) );
+			?>
+		<?php } else { ?>
+			<?php
+			wp_nav_menu( array(
+				'theme_location'  => 'member-logged-out',
+				'container'       => 'nav',
+				'container_id'    => 'member-navigation',
+				'container_class' => 'member-navigation',
+				'fallback_cb'     => 'memberlite_member_menu_cb',
+				'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				'walker'          => new Memberlite_Aria_Walker_Nav_Menu(),
+			) );
+			?>
+		<?php } ?>
+	</div><!-- .meta-member-inner -->
+</div><!-- #meta-member -->
+</div><!-- .wp-block-memberlite-member-info -->

--- a/src/blocks/nav-menu/block.json
+++ b/src/blocks/nav-menu/block.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "memberlite/nav-menu",
+    "version": "1.0.0",
+    "title": "Nav Menu",
+    "category": "memberlite",
+    "description": "Renders a WordPress classic navigation menu by theme location.",
+    "icon": "menu",
+    "supports": {
+        "html": false,
+        "reusable": false,
+        "lock": false,
+        "align": ["wide", "full"],
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "fontFamily": true,
+            "fontWeight": true,
+            "fontStyle": true,
+            "lineHeight": true,
+            "letterSpacing": true,
+            "textTransform": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        }
+    },
+    "attributes": {
+        "menuLocation": {
+            "type": "string",
+            "default": "primary"
+        }
+    },
+    "render": "file:./render.php",
+    "editorScript": "memberlite-block-nav-menu-editor",
+    "editorStyle": "file:./index.css",
+    "textdomain": "memberlite"
+}

--- a/src/blocks/nav-menu/editor.css
+++ b/src/blocks/nav-menu/editor.css
@@ -1,0 +1,37 @@
+/*
+ * Editor preview styles for the memberlite/nav-menu block.
+ *
+ * Mirrors the key frontend rules from _header.scss so the ServerSideRender
+ * preview looks like the real nav bar. Sub-menus and toggle buttons are hidden
+ * so only the first tier is visible in the editor.
+ */
+
+.wp-block-memberlite-nav-menu #site-navigation ul.menu {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wp-block-memberlite-nav-menu #site-navigation ul.menu > li.menu-item {
+	margin: 0;
+	position: relative;
+}
+
+.wp-block-memberlite-nav-menu #site-navigation ul.menu > li.menu-item > a {
+	color: inherit;
+	display: block;
+	overflow-wrap: normal;
+	padding: var( --wp--preset--spacing--20, 0.75rem ) var( --wp--preset--spacing--10, 0.5rem );
+	pointer-events: none;
+	text-decoration: none;
+	word-break: normal;
+}
+
+/* Hide sub-menus and dropdown toggle buttons — first tier only */
+.wp-block-memberlite-nav-menu #site-navigation ul.sub-menu,
+.wp-block-memberlite-nav-menu #site-navigation button {
+	display: none;
+}

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -1,0 +1,47 @@
+import './editor.css';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ServerSideRender from '@wordpress/server-side-render';
+import metadata from './block.json';
+
+const MENU_LOCATIONS = [
+	{ label: __( 'Primary', 'memberlite' ), value: 'primary' },
+	{ label: __( 'Member (logged in)', 'memberlite' ), value: 'member' },
+	{ label: __( 'Member (logged out)', 'memberlite' ), value: 'member-logged-out' },
+	{ label: __( 'Footer', 'memberlite' ), value: 'footer' },
+];
+
+function Edit( { attributes, setAttributes } ) {
+	const { menuLocation } = attributes;
+	const blockProps = useBlockProps();
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
+					<SelectControl
+						label={ __( 'Menu Location', 'memberlite' ) }
+						value={ menuLocation }
+						options={ MENU_LOCATIONS }
+						onChange={ ( value ) =>
+							setAttributes( { menuLocation: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<ServerSideRender
+					block="memberlite/nav-menu"
+					attributes={ attributes }
+				/>
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Server-side render for the memberlite/nav-menu block.
+ *
+ * Available variables:
+ *   $attributes  (array)          Block attributes.
+ *   $content     (string)         Inner block content (unused — no inner blocks).
+ *   $block       (WP_Block)       Block instance.
+ *
+ * @package Memberlite
+ * @since TBD
+ */
+
+$menu_location = $attributes['menuLocation'] ?? 'primary';
+
+if ( ! has_nav_menu( $menu_location ) ) {
+	return;
+}
+$wrapper_attributes = get_block_wrapper_attributes( array(
+	'id'         => 'site-navigation',
+	'role'       => 'navigation',
+	'aria-label' => __( 'Main Menu', 'memberlite' ),
+) );
+?>
+<nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php
+	wp_nav_menu( array(
+		'theme_location' => $menu_location,
+		'container'      => false,
+		'fallback_cb'    => false,
+		'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+		'menu_class'     => 'menu',
+		'walker'         => new Memberlite_Aria_Walker_Nav_Menu(),
+	) );
+	?>
+</nav><!-- #site-navigation -->

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -11,15 +11,19 @@
  * @since TBD
  */
 
-$menu_location = $attributes['menuLocation'] ?? 'primary';
+$menu_location = sanitize_key( $attributes['menuLocation'] ?? 'primary' );
 
 if ( ! has_nav_menu( $menu_location ) ) {
 	return;
 }
+
+$registered_menus = get_registered_nav_menus();
+$aria_label       = $registered_menus[ $menu_location ] ?? __( 'Navigation', 'memberlite' );
+
 $wrapper_attributes = get_block_wrapper_attributes( array(
 	'id'         => 'site-navigation',
 	'role'       => 'navigation',
-	'aria-label' => __( 'Main Menu', 'memberlite' ),
+	'aria-label' => $aria_label,
 ) );
 ?>
 <nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -259,6 +259,108 @@ hr.wp-block-separator {
 }
 
 // -----------------------------------------------------------------------------
+// Nav Menu Block (memberlite/nav-menu)
+// The render uses get_block_wrapper_attributes() on the <nav>, so the element
+// carries both id="site-navigation" AND class="wp-block-memberlite-nav-menu".
+// .site-header #site-navigation in _header.scss has specificity (1,1,0).
+// The compound selector below bumps to (1,2,0) so it wins regardless of load order.
+// -----------------------------------------------------------------------------
+
+.site-header #site-navigation.wp-block-memberlite-nav-menu {
+	background-color: unset;
+	color: unset;
+	clear: unset;
+}
+
+// -----------------------------------------------------------------------------
+// Member Info Block (memberlite/member-info)
+// Layout and menu structure only — colors, background, font-size, and
+// font-family are left to block supports (color, typography settings).
+// -----------------------------------------------------------------------------
+
+.wp-block-memberlite-member-info {
+	#meta-member {
+		display: flex;
+		justify-content: flex-end;
+
+		.fa-user {
+			margin-right: 3px;
+		}
+
+		.meta-member-inner {
+
+			li.menu-item-depth-0 {
+				padding: 0;
+			}
+		}
+
+		.user {
+			margin: 0 calc(var(--wp--preset--spacing--10) / 2);
+
+			a {
+				font-weight: 700;
+				padding: calc(var(--wp--preset--spacing--10) / 2) 0;
+			}
+		}
+
+		a {
+			display: inline-block;
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		// Inline member links (e.g. "My Account | Log Out")
+		.member-navigation,
+		.member-navigation > ul {
+			display: inline;
+
+			@include breakpoint(tablet) {
+				margin: 0;
+			}
+		}
+
+		.member-navigation {
+			li {
+				display: inline-block;
+				margin: 0;
+				position: relative;
+
+				&:last-child { border: none; }
+			}
+
+			a {
+				margin: 0;
+				padding: calc(var(--wp--preset--spacing--10) / 2);
+			}
+
+			.sub-menu {
+				background-color: inherit;
+
+				li a {
+					min-width: 100%;
+				}
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Site Title & Site Tagline Blocks
+// Prevent mid-word breaks when inside flex rows/groups — both frontend and editor.
+// -----------------------------------------------------------------------------
+
+.wp-block-site-title,
+.wp-block-site-tagline {
+	overflow-wrap: normal;
+	word-break: normal;
+	overflow: visible;
+	min-width: 0;
+}
+
+// -----------------------------------------------------------------------------
 // Social Links Block
 // -----------------------------------------------------------------------------
 

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -219,7 +219,7 @@
 			}
 
 			.member-navigation {
-					li {
+				li {
 					display: inline-block;
 					margin: 0;
 					position: relative;
@@ -237,9 +237,9 @@
 
 					li a { min-width: 100%; }
 				}
-
 			}
 		}
+
 	}
 
 	// -------------------------------------------------------------------------
@@ -299,6 +299,24 @@
 	.header-right #meta-member a,
 	.header-right #meta-member .meta-member-inner {
 		color: var(--memberlite-color-site-background);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CPT-based header variations
+// .site-header-mobile-row  — logo + toggle, visible on mobile only
+// .site-header-variation   — block editor content, visible on tablet+ only
+// -----------------------------------------------------------------------------
+
+.site-header-mobile-row {
+	@include breakpoint(tablet) {
+		display: none;
+	}
+}
+
+.site-header-variation {
+	@include breakpoint(mobile) {
+		display: none;
 	}
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		'editor/custom-settings': path.resolve( process.cwd(), 'src/editor/custom-settings.js' ),
-		// Add more entries as needed
-		// 'blocks/my-block/index': path.resolve( process.cwd(), 'src/blocks/my-block/index.js' ),
+		'blocks/nav-menu/index': path.resolve( process.cwd(), 'src/blocks/nav-menu/index.js' ),
+		'blocks/member-info/index': path.resolve( process.cwd(), 'src/blocks/member-info/index.js' ),
 	},
 };


### PR DESCRIPTION
Introduces a CPT-based header system alongside the existing header, so site admins can build custom headers in the block editor without touching PHP.

How it works

- A new memberlite_header CPT stores header layouts as block editor content. It's accessible under Memberlite → Headers in the admin.
- Two new custom blocks ship with the theme: Nav Menu (renders a classic menu by theme location) and Member Info (shows login/welcome/membernav). Both support block color and typography settings.
- Three starter patterns are included (header-01, header-02, header-03) that appear when creating a new Header Variation post.
- In the Customizer under Header, a new Default Header dropdown lets you select any published header post. When a CPT header is selected, the default settings (columns ratio, sticky nav, etc.) are hidden via active_callback.
- header.php checks memberlite_is_default_header_active() and either renders the existing template part or outputs: a mobile branding
row (header-mobile-row.php) + the block content + the mobile menu. The mobile row is hidden on tablet+ via CSS; the block variation is hidden on mobile.

Backwards compatible .