### PR TITLE
Fix sub-menu background color inheritance from nav-menu block settings 

### DIFF
--- a/patterns/header-02.php
+++ b/patterns/header-02.php
@@ -26,7 +26,7 @@
 <!-- wp:social-link {"url":"#","service":"youtube"} /--></ul>
 <!-- /wp:social-links -->
 
-<!-- wp:memberlite/member-info /--></div>
+<!-- wp:memberlite/member-info {"backgroundColor":"footer-widgets-background"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/src/blocks/member-info/block.json
+++ b/src/blocks/member-info/block.json
@@ -10,7 +10,12 @@
     "supports": {
         "html": false,
         "reusable": false,
-        "lock": false
+        "lock": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        }
     },
     "attributes": {
         "showWelcomeMessage": {

--- a/src/blocks/member-info/render.php
+++ b/src/blocks/member-info/render.php
@@ -16,9 +16,23 @@
 
 global $current_user, $pmpro_pages;
 
-$show_welcome        = $attributes['showWelcomeMessage'] ?? true;
+$show_welcome = $attributes['showWelcomeMessage'] ?? true;
 
-$wrapper_attributes = get_block_wrapper_attributes();
+// Propagate the background color to sub-menus via a CSS custom property.
+$nav_style_vars = '';
+if ( ! empty( $attributes['backgroundColor'] ) ) {
+	$slug           = sanitize_key( $attributes['backgroundColor'] );
+	$nav_style_vars = '--memberlite-color-navigation-block-background:var(--wp--preset--color--' . $slug . ');';
+} elseif ( ! empty( $attributes['style']['color']['background'] ) ) {
+	$nav_style_vars = '--memberlite-color-navigation-block-background:' . esc_attr( $attributes['style']['color']['background'] ) . ';';
+}
+
+$extra_attrs = array();
+if ( $nav_style_vars ) {
+	$extra_attrs['style'] = $nav_style_vars;
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( $extra_attrs );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 <div id="meta-member">

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -20,11 +20,25 @@ if ( ! has_nav_menu( $menu_location ) ) {
 $registered_menus = get_registered_nav_menus();
 $aria_label       = $registered_menus[ $menu_location ] ?? __( 'Navigation', 'memberlite' );
 
-$wrapper_attributes = get_block_wrapper_attributes( array(
+// Propagate the background color to sub-menus via a CSS custom property.
+$nav_style_vars = '';
+if ( ! empty( $attributes['backgroundColor'] ) ) {
+	$slug           = sanitize_key( $attributes['backgroundColor'] );
+	$nav_style_vars = '--memberlite-color-navigation-block-background:var(--wp--preset--color--' . $slug . ');';
+} elseif ( ! empty( $attributes['style']['color']['background'] ) ) {
+	$nav_style_vars = '--memberlite-color-navigation-block-background:' . esc_attr( $attributes['style']['color']['background'] ) . ';';
+}
+
+$extra_attrs = array(
 	'id'         => 'site-navigation',
 	'role'       => 'navigation',
 	'aria-label' => $aria_label,
-) );
+);
+if ( $nav_style_vars ) {
+	$extra_attrs['style'] = $nav_style_vars;
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( $extra_attrs );
 ?>
 <nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<?php

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -337,7 +337,7 @@ hr.wp-block-separator {
 			}
 
 			.sub-menu {
-				background-color: inherit;
+				background-color: var(--memberlite-color-navigation-block-background, var(--memberlite-color-site-navigation-background));
 
 				li a {
 					min-width: 100%;

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -391,7 +391,7 @@
 				margin: 0;
 				width: max-content;
 				max-width: 210px;
-				background-color: var(--memberlite-color-site-navigation-background);
+				background-color: var(--memberlite-color-navigation-block-background, var(--memberlite-color-site-navigation-background));
 				box-shadow: 4px 12px 16px 0 rgba(0, 0, 0, 0.12);
 				text-align: left;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a background color is assigned to the memberlite/nav-menu block in the editor, it was only applied to the 
outer <nav> element. The dropdown .sub-menu flyouts kept the theme's default nav background instead.

This PR bridges the gap using a CSS custom property (--memberlite-color-navigation-block-background), which does   
inherit through the cascade including to absolutely-positioned descendants.

- render.php: detects the block's background color (preset slug or custom hex) and injects it as  `--memberlite-color-navigation-block-background` via `get_block_wrapper_attributes()`.
- _header.scss: `.sub-menu` background-color now uses `var(--memberlite-color-navigation-block-background,
var(--memberlite-color-site-navigation-background))`, falling back to the theme default when no block color is  
set

### How to test the changes in this Pull Request:

1. Create a header with the Nav block.
2. Choose a menu with dropdown items.
3. Set a background color using either a named color or a custom color via color picker.

Observe on the frontend that the bg color cascades to the sub menu.

You can also NOT set any custom bg color and instead, change the Customizer > Colors setting for Primary Navigation bg. Without colors set on the nav menu block directly, the sub-menu should inherit that theme-wide color setting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?