### PR TITLE
Deprecate the memberlite_get_variation function from 7.0

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -582,7 +582,6 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
  * @return string
  */
 function memberlite_get_variation( $slug ) {
-	// Trigger a deprecation notice
 	_deprecated_function( __FUNCTION__, '7.1' );
 
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -579,7 +579,7 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
  *
  * @return string
  */
-function memberlite_get_variation( $slug = '' ){
+function memberlite_get_variation( $slug ){
 	// Trigger a deprecation notice
 	_deprecated_function( __FUNCTION__, '7.1', 'memberlite_get_variation' );
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -583,7 +583,7 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
  */
 function memberlite_get_variation( $slug ){
 	// Trigger a deprecation notice
-	_deprecated_function( __FUNCTION__, '7.1', '' );
+	_deprecated_function( __FUNCTION__, '7.1' );
 
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
 	return 'default';

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -569,3 +569,20 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
 		),
 	);
 }
+
+/**
+ * Helper function meant to fetch template parts based on variation
+ *
+ * @since 7.1
+ *
+ * @param $slug
+ *
+ * @return string
+ */
+function memberlite_get_variation( $slug ){
+	// Trigger a deprecation notice
+	_deprecated_function( __FUNCTION__, '7.1.0', 'memberlite_get_variation' );
+
+	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
+	return 'default';
+}

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -579,9 +579,9 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
  *
  * @return string
  */
-function memberlite_get_variation( $slug ){
+function memberlite_get_variation( $slug = '' ){
 	// Trigger a deprecation notice
-	_deprecated_function( __FUNCTION__, '7.1.0', 'memberlite_get_variation' );
+	_deprecated_function( __FUNCTION__, '7.1', 'memberlite_get_variation' );
 
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
 	return 'default';

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -581,7 +581,7 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
  * @param string $slug
  * @return string
  */
-function memberlite_get_variation( $slug ){
+function memberlite_get_variation( $slug ) {
 	// Trigger a deprecation notice
 	_deprecated_function( __FUNCTION__, '7.1' );
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -571,17 +571,19 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
 }
 
 /**
- * Helper function meant to fetch template parts based on variation
+ * Helper function meant to fetch template parts based on variation.
+ * $slug kept for backwards compatibility.
+ * Always returns 'default'.
  *
  * @since 7.0
  * @deprecated 7.1
  *
- * @param $slug
+ * @param string $slug
  * @return string
  */
 function memberlite_get_variation( $slug ){
 	// Trigger a deprecation notice
-	_deprecated_function( __FUNCTION__, '7.1', 'memberlite_get_variation' );
+	_deprecated_function( __FUNCTION__, '7.1', '' );
 
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
 	return 'default';

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -573,10 +573,10 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
 /**
  * Helper function meant to fetch template parts based on variation
  *
- * @since 7.1
+ * @since 7.0
+ * @deprecated 7.1
  *
  * @param $slug
- *
  * @return string
  */
 function memberlite_get_variation( $slug ){


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Deprecated the `memberlite_get_variation` function introduced in Memberlite 7.0. When current users update to the release that contains the header/footer variations feature, the "legacy" footer should remain on the front-end unaffected and without fatal errors.

### How to test the changes in this Pull Request:

N/A (Will need to test when the release is ready/complete)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Deprecated the `memberlite_get_variation` function introduced in Memberlite 7.0
