### PR TITLE
Bug Fix: Add height 100% to third level sub-menus so that they span the height of their parent links

### DIFF
--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -388,6 +388,7 @@
 			// Third-level sub-menus need explicit width due to absolute positioning
 			ul.sub-menu {
 				width: 100%;
+				height: 100%;
 			}
 		}
 

--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -372,6 +372,7 @@
 				z-index: 99999;
 				margin: 0;
 				width: max-content;
+				min-width: 100px;
 				max-width: 210px;
 				background-color: var(--memberlite-color-site-navigation-background);
 				box-shadow: 4px 12px 16px 0 rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves an issue where really long second level links make any sub-menus in them (third level) unreachable by mouse. What happens is the third level link, assuming it's not equally long as it's parent, the height isn't tall enough for your mouse to move into and instead it reads as you mousing off/away from the navigation. Therefore closing the navigation. Bug visible in the recording: [https://www.awesomescreenshot.com/video/51580751?key=f26baf9a984bc44d224d25d409de6c79](https://www.awesomescreenshot.com/video/51580751?key=f26baf9a984bc44d224d25d409de6c79)

### How to test the changes in this Pull Request:

In your header navigation, could be primary or the header widgets area, either way, make sure you have a really long "second level" link. Then add an additional child/sub-menu for that really long link. Confirm that you're able to use your mouse to go from that second level to that third level link without the navigation closing on you.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> CSS fix for third level header navigation sub-menus that were unreachable by mouse when second level links were too long/tall.
