### PR TITLE
Pull menu locations into Nav Menu block dynamically

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -5,3 +5,19 @@
 	order: -1;
 	margin-right: 5px;
 }
+
+label[for="memberlite-menu-location-select"] {
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	text-transform: uppercase;
+	display: block;
+	margin-bottom: calc(8px);
+	padding: 0;
+}
+
+#memberlite-menu-location-select {
+	width: 100%;
+	min-height: 40px;
+	padding-inline: 12px 30px;
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -48,6 +48,12 @@ function memberlite_register_blocks(): void {
 	);
 	register_block_type( get_template_directory() . '/build/blocks/nav-menu' );
 
+	wp_localize_script('memberlite-block-nav-menu-editor', 'active_pmpro_plugins',
+		array(
+			'nav_menu_plugin_active' => function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php')
+		)
+	);
+
 	// Member Info block.
 	wp_register_script(
 		'memberlite-block-member-info-editor',

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -74,7 +74,7 @@ add_action( 'init', 'memberlite_register_blocks' );
  *
  * @return array
  */
-function memberlite_allowed_blocks( $allowed_block_types, $editor_context ): array {
+function memberlite_allowed_blocks( $allowed_block_types, $editor_context ) {
 	$disallowed_blocks = array();
 
 	if ( ! isset( $editor_context->post->post_type ) ) {

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -42,7 +42,7 @@ function memberlite_register_blocks(): void {
 	wp_register_script(
 		'memberlite-block-nav-menu-editor',
 		get_template_directory_uri() . '/build/blocks/nav-menu/index.js',
-		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-api-fetch' ),
 		MEMBERLITE_VERSION,
 		true
 	);
@@ -75,8 +75,13 @@ add_action( 'init', 'memberlite_register_blocks' );
  * @return array
  */
 function memberlite_allowed_blocks( $allowed_block_types, $editor_context ): array {
-	$post_type         = $editor_context->post->post_type ?? '';
 	$disallowed_blocks = array();
+
+	if ( ! isset( $editor_context->post->post_type ) ) {
+		return $allowed_block_types;
+	}
+
+	$post_type = $editor_context->post->post_type;
 
 	if ( ! in_array( $post_type, array( 'memberlite_footer', 'memberlite_header' ), true ) ) {
 		$disallowed_blocks = array(

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -59,3 +59,46 @@ function memberlite_register_blocks(): void {
 	register_block_type( get_template_directory() . '/build/blocks/member-info' );
 }
 add_action( 'init', 'memberlite_register_blocks' );
+
+/**
+ * Only allow Memberlite's Nav Menu block on the memberlite_header and memberlite_footer post types.
+ *
+ * @param $allowed_block_types
+ * @param $editor_context
+ *
+ * @return array
+ */
+function memberlite_allowed_blocks( $allowed_block_types, $editor_context ): array {
+	$post_type         = $editor_context->post->post_type ?? '';
+	$disallowed_blocks = array();
+
+	if ( ! in_array( $post_type, array( 'memberlite_footer', 'memberlite_header' ), true ) ) {
+		$disallowed_blocks = array(
+			'memberlite/nav-menu',
+		);
+	}
+
+	// Get all registered blocks if $allowed_block_types is not already set.
+	if ( ! is_array( $allowed_block_types ) || empty( $allowed_block_types ) ) {
+		$registered_blocks   = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		$allowed_block_types = array_keys( $registered_blocks );
+	}
+
+	// Create a new array for the allowed blocks.
+	$filtered_blocks = array();
+
+	// Loop through each block in the allowed blocks list.
+	foreach ( $allowed_block_types as $block ) {
+
+		// Check if the block is not in the disallowed blocks list.
+		if ( ! in_array( $block, $disallowed_blocks, true ) ) {
+
+			// If it's not disallowed, add it to the filtered list.
+			$filtered_blocks[] = $block;
+		}
+	}
+
+	// Return the filtered list of allowed blocks
+	return $filtered_blocks;
+}
+add_filter( 'allowed_block_types_all', 'memberlite_allowed_blocks', 10, 2 );

--- a/src/blocks/nav-menu/block.json
+++ b/src/blocks/nav-menu/block.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "Nav Menu",
     "category": "memberlite",
-    "description": "Renders a WordPress classic navigation menu by theme location.",
+    "description": "Renders a WordPress classic navigation menu.",
     "icon": "menu",
     "supports": {
         "html": false,
@@ -34,7 +34,7 @@
         }
     },
     "attributes": {
-        "menuLocation": {
+        "selectedMenu": {
             "type": "string",
             "default": "primary"
         }

--- a/src/blocks/nav-menu/block.json
+++ b/src/blocks/nav-menu/block.json
@@ -36,7 +36,7 @@
     "attributes": {
         "selectedMenu": {
             "type": "string",
-            "default": "primary"
+            "default": ""
         }
     },
     "render": "file:./render.php",

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -13,27 +13,29 @@ function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const [menuLocations, setMenuLocations] = useState([]);
 
-	useEffect(() => {
-		apiFetch({ path: '/wp/v2/menu-locations' })
-			.then((locations) => {
-				const options = Object.entries(locations).map(([value, location]) => ({
+	useEffect( () => {
+		apiFetch( { path: '/wp/v2/menu-locations' } )
+			.then( ( locations ) => {
+				const options = Object.entries( locations ).map( ( [value, location] ) => ( {
 					label: location.description,
 					value: value,
-				}));
-				setMenuLocations(options);
+				} ) );
+				setMenuLocations( options);
 			})
-			.catch((err) => console.error('Failed to fetch menu locations:', err));
-	}, []);
+			.catch( ( err ) => console.error('Failed to fetch menu locations:', err) );
+	}, [] );
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
 					<SelectControl
-						label={__('Menu Location', 'memberlite')}
-						value={menuLocation}
-						options={menuLocations}
-						onChange={(value) => setAttributes({ menuLocation: value })}
+						label={ __('Menu Location', 'memberlite') }
+						value={ menuLocation }
+						options={ menuLocations }
+						onChange={ ( value ) =>
+							setAttributes( { menuLocation: value } )
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -11,7 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
-	const [menuLocations, setMenuLocations] = useState([]);
+	const [ menuLocations, setMenuLocations ] = useState([]);
 
 	useEffect( () => {
 		apiFetch( { path: '/wp/v2/menu-locations' } )

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -11,18 +11,20 @@ import apiFetch from '@wordpress/api-fetch';
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
-	const [ menuLocations, setMenuLocations ] = useState([]);
+	const [ menuLocations, setMenuLocations ] = useState( [] );
 
 	useEffect( () => {
 		apiFetch( { path: '/wp/v2/menu-locations' } )
 			.then( ( locations ) => {
-				const options = Object.entries( locations ).map( ( [value, location] ) => ( {
+				const options = Object.entries( locations ).map( ( [value, location ] ) => ( {
 					label: location.description,
 					value: value,
 				} ) );
-				setMenuLocations( options);
+				setMenuLocations( options );
 			})
-			.catch( ( err ) => console.error('Failed to fetch menu locations:', err) );
+			.catch( ( err ) =>
+				console.error( 'Failed to fetch menu locations:', err )
+			);
 	}, [] );
 
 	return (
@@ -30,7 +32,7 @@ function Edit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
 					<SelectControl
-						label={ __('Menu Location', 'memberlite') }
+						label={ __( 'Menu Location', 'memberlite' ) }
 						value={ menuLocation }
 						options={ menuLocations }
 						onChange={ ( value ) =>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -5,29 +5,35 @@ import { PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 import metadata from './block.json';
-
-const MENU_LOCATIONS = [
-	{ label: __( 'Primary', 'memberlite' ), value: 'primary' },
-	{ label: __( 'Member (logged in)', 'memberlite' ), value: 'member' },
-	{ label: __( 'Member (logged out)', 'memberlite' ), value: 'member-logged-out' },
-	{ label: __( 'Footer', 'memberlite' ), value: 'footer' },
-];
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
+	const [menuLocations, setMenuLocations] = useState([]);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/menu-locations' })
+			.then((locations) => {
+				const options = Object.entries(locations).map(([value, location]) => ({
+					label: location.description,
+					value: value,
+				}));
+				setMenuLocations(options);
+			})
+			.catch((err) => console.error('Failed to fetch menu locations:', err));
+	}, []);
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
 					<SelectControl
-						label={ __( 'Menu Location', 'memberlite' ) }
-						value={ menuLocation }
-						options={ MENU_LOCATIONS }
-						onChange={ ( value ) =>
-							setAttributes( { menuLocation: value } )
-						}
+						label={__('Menu Location', 'memberlite')}
+						value={menuLocation}
+						options={menuLocations}
+						onChange={(value) => setAttributes({ menuLocation: value })}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -63,6 +63,8 @@ function Edit( { attributes, setAttributes } ) {
 						label={ __( 'Menu Location', 'memberlite' ) }
 						value={ menuLocation }
 						options={ menuLocations }
+						disabled={ isLoading }
+						help={ menuLocationsError || undefined }
 						onChange={ ( value ) =>
 							setAttributes( { menuLocation: value } )
 						}

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -8,10 +8,24 @@ import metadata from './block.json';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
+const FALLBACK_MENU_LOCATIONS  = [
+	{ label: __( 'Primary', 'memberlite' ), value: 'primary' },
+	{ label: __( 'Member (logged in)', 'memberlite' ), value: 'member' },
+	{ label: __( 'Member (logged out)', 'memberlite' ), value: 'member-logged-out' },
+	{ label: __( 'Footer', 'memberlite' ), value: 'footer' },
+];
+
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
-	const [ menuLocations, setMenuLocations ] = useState( [] );
+	const [ menuLocations, setMenuLocations ] = useState( [
+		{
+			label: __( 'Loading menu locations…', 'memberlite' ),
+			value: '',
+		},
+	] );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ menuLocationsError, setMenuLocationsError ] = useState( '' );
 
 	useEffect( () => {
 		apiFetch( { path: '/wp/v2/menu-locations' } )
@@ -20,11 +34,25 @@ function Edit( { attributes, setAttributes } ) {
 					label: location.description,
 					value: value,
 				} ) );
-				setMenuLocations( options );
-			})
-			.catch( ( err ) =>
-				console.error( 'Failed to fetch menu locations:', err )
-			);
+
+				setMenuLocations(
+					options.length
+						? options
+						: FALLBACK_MENU_LOCATIONS
+				);
+
+				setMenuLocationsError( '' );
+				setIsLoading( false );
+			} )
+			.catch( ( err ) => {
+				console.error( 'Failed to fetch menu locations:', err );
+
+				setMenuLocations( FALLBACK_MENU_LOCATIONS );
+				setMenuLocationsError(
+					__( 'Menu locations could not be loaded. Showing defaults.', 'memberlite' )
+				);
+				setIsLoading( false );
+			} );
 	}, [] );
 
 	return (

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -15,9 +15,17 @@ const FALLBACK_MENU_LOCATIONS  = [
 	{ label: __( 'Footer', 'memberlite' ), value: 'footer' },
 ];
 
+const NO_MENUS_MESSAGE = __( 'No menus found.', 'memberlite' );
+
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
+	const [ menus, setMenus ] = useState( [
+		{
+			label: __( 'Loading menus…', 'memberlite' ),
+			value: '',
+		},
+	] );
 	const [ menuLocations, setMenuLocations ] = useState( [
 		{
 			label: __( 'Loading menu locations…', 'memberlite' ),
@@ -25,7 +33,7 @@ function Edit( { attributes, setAttributes } ) {
 		},
 	] );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ menuLocationsError, setMenuLocationsError ] = useState( '' );
+	const [ menuLocationsError, setMenuLocationsError, menusError, setMenusError ] = useState( '' );
 
 	useEffect( () => {
 		apiFetch( { path: '/wp/v2/menu-locations' } )
@@ -53,6 +61,48 @@ function Edit( { attributes, setAttributes } ) {
 				);
 				setIsLoading( false );
 			} );
+
+		apiFetch( { path: '/wp/v2/menus' } )
+			.then( ( menus ) => {
+				const menuOptions = menus.map( ( menu ) => ( {
+					label: menu.name,
+					value: menu.slug,
+				} ) );
+
+				setMenus(
+					menuOptions.length
+						? menuOptions
+						: NO_MENUS_MESSAGE
+				);
+
+				setMenusError( '' );
+				setIsLoading( false );
+
+			} )
+			.catch( ( err ) => {
+				console.error( 'Failed to fetch menus:', err );
+
+				setMenus( NO_MENUS_MESSAGE );
+				setMenuLocationsError(
+					__( 'Menus could not be loaded.', 'memberlite' )
+				);
+				setIsLoading( false );
+			} );
+
+		const combineOptions = <optgroup label={ __( 'Menus', 'memberlite' ) } >
+			{ menus.map( ( menu ) => (
+					<option key={ menu.value } value={ menu.value }>
+						{ menu.label }
+					</option>
+				) ) }
+		</optgroup>
+		<optgroup label={ __( 'Menu Locations', 'memberlite' ) } >
+			{ locations.map( ( location ) => (
+				<option key={ location.value } value={ location.value }>
+					{ location.label }
+				</option>
+			) ) }
+		</optgroup>
 	}, [] );
 
 	return (
@@ -60,7 +110,7 @@ function Edit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
 					<SelectControl
-						label={ __( 'Menu Location', 'memberlite' ) }
+						label={ __( 'Select Menu', 'memberlite' ) }
 						value={ menuLocation }
 						options={ menuLocations }
 						disabled={ isLoading }

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -40,14 +40,6 @@ function Edit( { attributes, setAttributes } ) {
 
 					setMenus( menuOptions );
 					setIsLoading( false );
-
-					// If no menu is selected yet, default to the first available option
-					if ( ! selectedMenu ) {
-						const firstOption = menuOptions[ 0 ] ?? FALLBACK_MENU_LOCATIONS[ 0 ];
-						if ( firstOption ) {
-							setAttributes( { selectedMenu: firstOption.value } );
-						}
-					}
 				} )
 				.catch( ( err ) => {
 					console.error( 'Failed to fetch menus:', err );
@@ -73,14 +65,6 @@ function Edit( { attributes, setAttributes } ) {
 					setLocations( locationOptions.length ? locationOptions : FALLBACK_MENU_LOCATIONS );
 					setMenus( menuOptions );
 					setIsLoading( false );
-
-					// If no menu is selected yet, default to the first available option
-					if ( ! selectedMenu ) {
-						const firstOption = menuOptions[ 0 ] ?? locationOptions[ 0 ] ?? FALLBACK_MENU_LOCATIONS[ 0 ];
-						if ( firstOption ) {
-							setAttributes( { selectedMenu: firstOption.value } );
-						}
-					}
 				} )
 				.catch( ( err ) => {
 					console.error( 'Failed to fetch menus or locations:', err );
@@ -112,6 +96,7 @@ function Edit( { attributes, setAttributes } ) {
 									value={ selectedMenu }
 									onChange={ ( e ) => setAttributes( { selectedMenu: e.target.value } ) }
 								>
+									<option value="">{ __( '-- No Menu Selected --', 'memberlite' ) }</option>
 									{ menus.length > 0 && (
 										<optgroup label={ __( 'By Menu', 'memberlite' ) }>
 											{ menus.map( ( opt ) => (

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -22,36 +22,60 @@ function Edit( { attributes, setAttributes } ) {
 	const [ menus, setMenus ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( '' );
+	// From wp_localize_script...
+	const navMenusAddOnActive = active_pmpro_plugins.nav_menu_plugin_active ?? false;
 
 	useEffect( () => {
 		const labels = window.memberliteBlockData?.menuLocationLabels || {};
 
-		Promise.all( [
-			apiFetch( { path: '/wp/v2/menu-locations' } ),
-			apiFetch( { path: '/wp/v2/menus' } ),
-		] )
-			.then( ( [ fetchedLocations, fetchedMenus ] ) => {
-				const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug, location ] ) => ( {
-					label: location.description || labels[ slug ] || slug,
-					value: `location:${ slug }`,
-				} ) );
+		if ( ! navMenusAddOnActive ) {
+			Promise.all( [
+				apiFetch( { path: '/wp/v2/menus' } ),
+			] )
+				.then( ( [ fetchedMenus ] ) => {
+					const menuOptions = fetchedMenus.map( ( menu ) => ( {
+						label: menu.name,
+						value: `menu:${ menu.id }`,
+					} ) );
 
-				const menuOptions = fetchedMenus.map( ( menu ) => ( {
-					label: menu.name,
-					value: `menu:${ menu.id }`,
-				} ) );
+					setMenus( menuOptions );
+					setIsLoading( false );
+				} )
+				.catch( ( err ) => {
+					console.error( 'Failed to fetch menus:', err );
+					setError( __( 'Could not load menus. Showing defaults.', 'memberlite' ) );
+					setIsLoading( false );
+				} );
+		} else {
+			Promise.all( [
+				apiFetch( { path: '/wp/v2/menu-locations' } ),
+				apiFetch( { path: '/wp/v2/menus' } ),
+			] )
+				.then( ( [ fetchedLocations, fetchedMenus ] ) => {
+					const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug, location ] ) => ( {
+						label: location.description || labels[ slug ] || slug,
+						value: `location:${ slug }`,
+					} ) );
 
-				setLocations( locationOptions.length ? locationOptions : FALLBACK_MENU_LOCATIONS );
-				setMenus( menuOptions );
-				setIsLoading( false );
-			} )
-			.catch( ( err ) => {
-				console.error( 'Failed to fetch menus or locations:', err );
-				setLocations( FALLBACK_MENU_LOCATIONS );
-				setError( __( 'Could not load menus. Showing defaults.', 'memberlite' ) );
-				setIsLoading( false );
-			} );
+					const menuOptions = fetchedMenus.map( ( menu ) => ( {
+						label: menu.name,
+						value: `menu:${ menu.id }`,
+					} ) );
+
+					setLocations( locationOptions.length ? locationOptions : FALLBACK_MENU_LOCATIONS );
+					setMenus( menuOptions );
+					setIsLoading( false );
+				} )
+				.catch( ( err ) => {
+					console.error( 'Failed to fetch menus or locations:', err );
+					setLocations( FALLBACK_MENU_LOCATIONS );
+					setError( __( 'Could not load menus. Showing defaults.', 'memberlite' ) );
+					setIsLoading( false );
+				} );
+		}
 	}, [] );
+
+	console.log( 'locations ', locations );
 
 	return (
 		<>
@@ -83,13 +107,15 @@ function Edit( { attributes, setAttributes } ) {
 											) ) }
 										</optgroup>
 									) }
-									<optgroup label={ __( 'By Location', 'memberlite' ) }>
-										{ locations.map( ( opt ) => (
-											<option key={ opt.value } value={ opt.value }>
-												{ opt.label }
-											</option>
-										) ) }
-									</optgroup>
+									{ navMenusAddOnActive && (
+										<optgroup label={ __( 'By Location', 'memberlite' ) }>
+											{ locations.map( ( opt ) => (
+												<option key={ opt.value } value={ opt.value }>
+													{ opt.label }
+												</option>
+											) ) }
+										</optgroup>
+									) }
 								</select>
 								{ menus.length === 0 && ! error && (
 									<p className="components-base-control__help">

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -75,8 +75,6 @@ function Edit( { attributes, setAttributes } ) {
 		}
 	}, [] );
 
-	console.log( 'locations ', locations );
-
 	return (
 		<>
 			<InspectorControls>
@@ -128,11 +126,6 @@ function Edit( { attributes, setAttributes } ) {
 									</p>
 								) }
 							</>
-						) }
-						{ error && (
-							<p className="components-base-control__help" style={ { color: 'red' } }>
-								{ error }
-							</p>
 						) }
 					</div>
 				</PanelBody>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -1,124 +1,115 @@
 import './editor.css';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 import metadata from './block.json';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
-const FALLBACK_MENU_LOCATIONS  = [
-	{ label: __( 'Primary', 'memberlite' ), value: 'primary' },
-	{ label: __( 'Member (logged in)', 'memberlite' ), value: 'member' },
-	{ label: __( 'Member (logged out)', 'memberlite' ), value: 'member-logged-out' },
-	{ label: __( 'Footer', 'memberlite' ), value: 'footer' },
+const FALLBACK_MENU_LOCATIONS = [
+	{ label: __( 'Primary', 'memberlite' ), value: 'location:primary' },
+	{ label: __( 'Member (logged in)', 'memberlite' ), value: 'location:member' },
+	{ label: __( 'Member (logged out)', 'memberlite' ), value: 'location:member-logged-out' },
+	{ label: __( 'Footer', 'memberlite' ), value: 'location:footer' },
 ];
-
-const NO_MENUS_MESSAGE = __( 'No menus found.', 'memberlite' );
 
 function Edit( { attributes, setAttributes } ) {
 	const { menuLocation } = attributes;
 	const blockProps = useBlockProps();
-	const [ menus, setMenus ] = useState( [
-		{
-			label: __( 'Loading menus…', 'memberlite' ),
-			value: '',
-		},
-	] );
-	const [ menuLocations, setMenuLocations ] = useState( [
-		{
-			label: __( 'Loading menu locations…', 'memberlite' ),
-			value: '',
-		},
-	] );
+	const [ locations, setLocations ] = useState( [] );
+	const [ menus, setMenus ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ menuLocationsError, setMenuLocationsError, menusError, setMenusError ] = useState( '' );
+	const [ error, setError ] = useState( '' );
 
 	useEffect( () => {
-		apiFetch( { path: '/wp/v2/menu-locations' } )
-			.then( ( locations ) => {
-				const options = Object.entries( locations ).map( ( [value, location ] ) => ( {
-					label: location.description,
-					value: value,
+		const labels = window.memberliteBlockData?.menuLocationLabels || {};
+
+		Promise.all( [
+			apiFetch( { path: '/wp/v2/menu-locations' } ),
+			apiFetch( { path: '/wp/v2/menus' } ),
+		] )
+			.then( ( [ fetchedLocations, fetchedMenus ] ) => {
+				const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug ] ) => ( {
+					// prefix value to avoid collision if a menu slug matches a location slug
+					label: labels[ slug ] || slug,
+					value: `location:${ slug }`,
 				} ) );
 
-				setMenuLocations(
-					options.length
-						? options
-						: FALLBACK_MENU_LOCATIONS
-				);
-
-				setMenuLocationsError( '' );
-				setIsLoading( false );
-			} )
-			.catch( ( err ) => {
-				console.error( 'Failed to fetch menu locations:', err );
-
-				setMenuLocations( FALLBACK_MENU_LOCATIONS );
-				setMenuLocationsError(
-					__( 'Menu locations could not be loaded. Showing defaults.', 'memberlite' )
-				);
-				setIsLoading( false );
-			} );
-
-		apiFetch( { path: '/wp/v2/menus' } )
-			.then( ( menus ) => {
-				const menuOptions = menus.map( ( menu ) => ( {
+				const menuOptions = fetchedMenus.map( ( menu ) => ( {
 					label: menu.name,
-					value: menu.slug,
+					value: `menu:${ menu.id }`,
 				} ) );
 
-				setMenus(
-					menuOptions.length
-						? menuOptions
-						: NO_MENUS_MESSAGE
-				);
-
-				setMenusError( '' );
+				setLocations( locationOptions.length ? locationOptions : FALLBACK_MENU_LOCATIONS );
+				setMenus( menuOptions );
 				setIsLoading( false );
-
 			} )
 			.catch( ( err ) => {
-				console.error( 'Failed to fetch menus:', err );
-
-				setMenus( NO_MENUS_MESSAGE );
-				setMenuLocationsError(
-					__( 'Menus could not be loaded.', 'memberlite' )
-				);
+				console.error( 'Failed to fetch menus or locations:', err );
+				setLocations( FALLBACK_MENU_LOCATIONS );
+				setError( __( 'Could not load menus. Showing defaults.', 'memberlite' ) );
 				setIsLoading( false );
 			} );
-
-		const combineOptions = <optgroup label={ __( 'Menus', 'memberlite' ) } >
-			{ menus.map( ( menu ) => (
-					<option key={ menu.value } value={ menu.value }>
-						{ menu.label }
-					</option>
-				) ) }
-		</optgroup>
-		<optgroup label={ __( 'Menu Locations', 'memberlite' ) } >
-			{ locations.map( ( location ) => (
-				<option key={ location.value } value={ location.value }>
-					{ location.label }
-				</option>
-			) ) }
-		</optgroup>
 	}, [] );
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Menu Settings', 'memberlite' ) }>
-					<SelectControl
-						label={ __( 'Select Menu', 'memberlite' ) }
-						value={ menuLocation }
-						options={ menuLocations }
-						disabled={ isLoading }
-						help={ menuLocationsError || undefined }
-						onChange={ ( value ) =>
-							setAttributes( { menuLocation: value } )
-						}
-					/>
+					<div className="memberlite-menu-select">
+						<label
+							className="components-base-control__label"
+							htmlFor="memberlite-menu-location-select"
+						>
+							{ __( 'Select Menu', 'memberlite' ) }
+						</label>
+						{ isLoading ? (
+							<p>{ __( 'Loading…', 'memberlite' ) }</p>
+						) : (
+							<>
+								<select
+									id="memberlite-menu-location-select"
+									className="components-select-control__input"
+									value={ menuLocation }
+									onChange={ ( e ) => setAttributes( { menuLocation: e.target.value } ) }
+								>
+									{ menus.length > 0 && (
+										<optgroup label={ __( 'By Menu', 'memberlite' ) }>
+											{ menus.map( ( opt ) => (
+												<option key={ opt.value } value={ opt.value }>
+													{ opt.label }
+												</option>
+											) ) }
+										</optgroup>
+									) }
+									<optgroup label={ __( 'By Location', 'memberlite' ) }>
+										{ locations.map( ( opt ) => (
+											<option key={ opt.value } value={ opt.value }>
+												{ opt.label }
+											</option>
+										) ) }
+									</optgroup>
+								</select>
+								{ menus.length === 0 && ! error && (
+									<p className="components-base-control__help">
+										{ __( 'No menus found. Create one under Appearance → Menus.', 'memberlite' ) }
+									</p>
+								) }
+								{ error && (
+									<p className="components-base-control__help" style={ { color: 'red' } }>
+										{ error }
+									</p>
+								) }
+							</>
+						) }
+						{ error && (
+							<p className="components-base-control__help" style={ { color: 'red' } }>
+								{ error }
+							</p>
+						) }
+					</div>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -16,7 +16,7 @@ const FALLBACK_MENU_LOCATIONS = [
 ];
 
 function Edit( { attributes, setAttributes } ) {
-	const { menuLocation } = attributes;
+	const { selectedMenu } = attributes;
 	const blockProps = useBlockProps();
 	const [ locations, setLocations ] = useState( [] );
 	const [ menus, setMenus ] = useState( [] );
@@ -31,9 +31,8 @@ function Edit( { attributes, setAttributes } ) {
 			apiFetch( { path: '/wp/v2/menus' } ),
 		] )
 			.then( ( [ fetchedLocations, fetchedMenus ] ) => {
-				const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug ] ) => ( {
-					// prefix value to avoid collision if a menu slug matches a location slug
-					label: labels[ slug ] || slug,
+				const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug, location ] ) => ( {
+					label: location.description || labels[ slug ] || slug,
 					value: `location:${ slug }`,
 				} ) );
 
@@ -72,8 +71,8 @@ function Edit( { attributes, setAttributes } ) {
 								<select
 									id="memberlite-menu-location-select"
 									className="components-select-control__input"
-									value={ menuLocation }
-									onChange={ ( e ) => setAttributes( { menuLocation: e.target.value } ) }
+									value={ selectedMenu }
+									onChange={ ( e ) => setAttributes( { selectedMenu: e.target.value } ) }
 								>
 									{ menus.length > 0 && (
 										<optgroup label={ __( 'By Menu', 'memberlite' ) }>

--- a/src/blocks/nav-menu/index.js
+++ b/src/blocks/nav-menu/index.js
@@ -40,6 +40,14 @@ function Edit( { attributes, setAttributes } ) {
 
 					setMenus( menuOptions );
 					setIsLoading( false );
+
+					// If no menu is selected yet, default to the first available option
+					if ( ! selectedMenu ) {
+						const firstOption = menuOptions[ 0 ] ?? FALLBACK_MENU_LOCATIONS[ 0 ];
+						if ( firstOption ) {
+							setAttributes( { selectedMenu: firstOption.value } );
+						}
+					}
 				} )
 				.catch( ( err ) => {
 					console.error( 'Failed to fetch menus:', err );
@@ -65,6 +73,14 @@ function Edit( { attributes, setAttributes } ) {
 					setLocations( locationOptions.length ? locationOptions : FALLBACK_MENU_LOCATIONS );
 					setMenus( menuOptions );
 					setIsLoading( false );
+
+					// If no menu is selected yet, default to the first available option
+					if ( ! selectedMenu ) {
+						const firstOption = menuOptions[ 0 ] ?? locationOptions[ 0 ] ?? FALLBACK_MENU_LOCATIONS[ 0 ];
+						if ( firstOption ) {
+							setAttributes( { selectedMenu: firstOption.value } );
+						}
+					}
 				} )
 				.catch( ( err ) => {
 					console.error( 'Failed to fetch menus or locations:', err );

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -24,7 +24,6 @@ if ( empty( $selected_menu ) ) {
 if ( strpos( $selected_menu, 'location:' ) === 0 && function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php') ) {
 	$slug = substr( $selected_menu, strlen( 'location:' ) );
 	if ( ! has_nav_menu( $slug ) ) {
-		error_log( 'has_nav_menu: false on post ID ' . get_the_ID() );
 		return;
 	}
 	$menu_type = 'location';
@@ -34,7 +33,6 @@ if ( strpos( $selected_menu, 'menu:' ) === 0 ) {
 	$id = (int) substr( $selected_menu, strlen( 'menu:' ) );
 
 	if ( ! is_nav_menu( $id ) ) {
-		error_log( 'is_nav_menu: false on post ID ' . get_the_ID() );
 		return;
 	}
 	$menu_type = 'menu';

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -21,17 +21,20 @@ if ( empty( $selected_menu ) ) {
 }
 
 // Uses prefix to distinguish between location and menu.
-if ( str_starts_with( $selected_menu, 'location:' ) && function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php') ) {
+if ( strpos( $selected_menu, 'location:' ) === 0 && function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php') ) {
 	$slug = substr( $selected_menu, strlen( 'location:' ) );
 	if ( ! has_nav_menu( $slug ) ) {
+		error_log( 'has_nav_menu: false on post ID ' . get_the_ID() );
 		return;
 	}
 	$menu_type = 'location';
 }
 
-if ( str_starts_with( $selected_menu, 'menu:' ) ) {
+if ( strpos( $selected_menu, 'menu:' ) === 0 ) {
 	$id = (int) substr( $selected_menu, strlen( 'menu:' ) );
+
 	if ( ! is_nav_menu( $id ) ) {
+		error_log( 'is_nav_menu: false on post ID ' . get_the_ID() );
 		return;
 	}
 	$menu_type = 'menu';

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -21,7 +21,7 @@ if ( empty( $selected_menu ) ) {
 }
 
 // Uses prefix to distinguish between location and menu.
-if ( str_starts_with( $selected_menu, 'location:' ) ) {
+if ( str_starts_with( $selected_menu, 'location:' ) && function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php') ) {
 	$slug = substr( $selected_menu, strlen( 'location:' ) );
 	if ( ! has_nav_menu( $slug ) ) {
 		return;

--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -11,20 +11,51 @@
  * @since TBD
  */
 
-$menu_location = sanitize_key( $attributes['menuLocation'] ?? 'primary' );
+$selected_menu = sanitize_text_field( $attributes['selectedMenu'] ?? '' );
+$menu_type     = '';
+$slug          = '';
+$id            = 0;
 
-if ( ! has_nav_menu( $menu_location ) ) {
+if ( empty( $selected_menu ) ) {
 	return;
 }
 
-$registered_menus = get_registered_nav_menus();
-$aria_label       = $registered_menus[ $menu_location ] ?? __( 'Navigation', 'memberlite' );
+// Uses prefix to distinguish between location and menu.
+if ( str_starts_with( $selected_menu, 'location:' ) ) {
+	$slug = substr( $selected_menu, strlen( 'location:' ) );
+	if ( ! has_nav_menu( $slug ) ) {
+		return;
+	}
+	$menu_type = 'location';
+}
 
-// Propagate the background color to sub-menus via a CSS custom property.
+if ( str_starts_with( $selected_menu, 'menu:' ) ) {
+	$id = (int) substr( $selected_menu, strlen( 'menu:' ) );
+	if ( ! is_nav_menu( $id ) ) {
+		return;
+	}
+	$menu_type = 'menu';
+}
+
+if ( empty( $menu_type ) ) {
+	return;
+}
+
+$default_aria_label = __( 'Navigation', 'memberlite' );
+
+if ( $menu_type === 'location' ) {
+	$registered_menus = get_registered_nav_menus();
+	$aria_label       = $registered_menus[ $slug ] ?? $default_aria_label;
+} else {
+	$menu_object = wp_get_nav_menu_object( $id );
+	$aria_label  = $menu_object ? $menu_object->name : $default_aria_label;
+}
+
 $nav_style_vars = '';
+
 if ( ! empty( $attributes['backgroundColor'] ) ) {
-	$slug           = sanitize_key( $attributes['backgroundColor'] );
-	$nav_style_vars = '--memberlite-color-navigation-block-background:var(--wp--preset--color--' . $slug . ');';
+	$bg_slug        = sanitize_key( $attributes['backgroundColor'] );
+	$nav_style_vars = '--memberlite-color-navigation-block-background:var(--wp--preset--color--' . $bg_slug . ');';
 } elseif ( ! empty( $attributes['style']['color']['background'] ) ) {
 	$nav_style_vars = '--memberlite-color-navigation-block-background:' . esc_attr( $attributes['style']['color']['background'] ) . ';';
 }
@@ -34,21 +65,35 @@ $extra_attrs = array(
 	'role'       => 'navigation',
 	'aria-label' => $aria_label,
 );
+
 if ( $nav_style_vars ) {
 	$extra_attrs['style'] = $nav_style_vars;
+}
+
+$menu_args = array(
+	'container'  => false,
+	'fallback_cb' => false,
+	'echo'        => false,
+	'items_wrap'  => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+	'menu_class'  => 'menu',
+	'walker'      => new Memberlite_Aria_Walker_Nav_Menu(),
+);
+
+$menu_args = array_merge(
+	$menu_args,
+	$menu_type === 'location'
+		? array( 'theme_location' => $slug )
+		: array( 'menu' => $id )
+);
+
+$nav_menu_output = wp_nav_menu( $menu_args );
+
+if ( empty( $nav_menu_output ) ) {
+	return;
 }
 
 $wrapper_attributes = get_block_wrapper_attributes( $extra_attrs );
 ?>
 <nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php
-	wp_nav_menu( array(
-		'theme_location' => $menu_location,
-		'container'      => false,
-		'fallback_cb'    => false,
-		'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-		'menu_class'     => 'menu',
-		'walker'         => new Memberlite_Aria_Walker_Nav_Menu(),
-	) );
-	?>
+	<?php echo $nav_menu_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </nav><!-- #site-navigation -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Nav Menu block pulls menus and menu locations dynamically via REST API endpoints. We've also restricted this block to the `memberlite_footer` and `memberlite_header` patterns.

**Out of the box:**

Memberlite's Nav Menu Block pulls menus to the block setting dynamically. If there are no menus to pull, a message should display.

<img width="263" height="313" alt="image" src="https://github.com/user-attachments/assets/686f8e26-13cc-4acb-8182-e89d2ef99fbb" />


**With the Nav Menu Add On:**

Pulls the menu locations dynamically. Any locations that do not have a menu assigned will show as an empty block. If the REST API request fails, it will use hardcoded menu locations as a fallback.

**Other Notes:**

We've separated the menus and menu locations in the setting by using `<optgroup>`. If someone selects a menu and saves it. Then either deletes that menu (or if it's a menu location, de-activates the Add On), then the block will show as "Block rendered as empty." We also have error handling in case the REST API endpoint fails to fetch either menus or menu locations.

<img width="380" height="619" alt="image" src="https://github.com/user-attachments/assets/71458e1c-415e-4dc6-9f54-4d862b21d11f" />

---

### How to test the changes in this Pull Request:

- Confirm that the Memberlite Nav Menu block is only present in the block inserter when you're editing a header/footer variation post under `Memberlite > Headers` or `Memberlite > Footers` (In the admin sidebar).
- With the PMPro Nav Menu Add On: Confirm that the block's setting pulls both menus directly and menu locations.
- Without the PMPro Nav Menu Add On: Confirm that the block's setting pulls only menus.
- Confirm that empty menus or menu locations without menus registered to them show as "Block rendered as empty" and there are no fatal errors or console errors.
- Confirm that if you select a menu, save the post, then delete the menu, that the block then renders as empty. No fatal errors. No console errors. 
- Confirm that if you select a menu location with a menu, save the post, then either remove the menu from that location or de-active the Add On, that the block renders as empty. No fatal errors. No console errors. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Pull menus and menu locations dynamically into Memberlite's Nav Menu block. Use hardcoded fallbacks if the REST API request for menu locations fail. Display an error message if there are no menus to pull. The block should only be available on our header and footer CPTs.
