### PR TITLE
Remove padding and background color from sidebar/widgets

### DIFF
--- a/src/scss/components/_widgets.scss
+++ b/src/scss/components/_widgets.scss
@@ -20,7 +20,6 @@
 
 	// Widget base
 	.widget {
-		border-radius: var(--wp--custom--border--radius);
 		overflow: hidden;
 		margin: 0 0 var(--wp--style--root--padding-right) 0;
 	}

--- a/src/scss/components/_widgets.scss
+++ b/src/scss/components/_widgets.scss
@@ -72,9 +72,6 @@
 
 	// Nav menu widget
 	.widget_nav_menu {
-		padding-left: var(--wp--style--root--padding-left);
-		padding-right: var(--wp--style--root--padding-right);
-
 		.widget-title {
 			margin-bottom: var(--wp--preset--spacing--20);
 		}

--- a/src/scss/components/_widgets.scss
+++ b/src/scss/components/_widgets.scss
@@ -20,21 +20,9 @@
 
 	// Widget base
 	.widget {
-		background-color: light-dark(
-			color-mix(in srgb, var(--memberlite-color-site-background), black 3%),
-			color-mix(in srgb, var(--memberlite-color-site-background), white 3%)
-		);
 		border-radius: var(--wp--custom--border--radius);
 		overflow: hidden;
 		margin: 0 0 var(--wp--style--root--padding-right) 0;
-
-		> :first-child {
-			padding-top: var(--wp--style--root--padding-top);
-		}
-
-		> :last-child {
-			padding-bottom: var(--wp--style--root--padding-bottom);
-		}
 	}
 
 	.widget-title {


### PR DESCRIPTION
Remove padding and background color from sidebar widgets. Will only affect the `.widget` class, which is a legacy class. Block versions of the "widgets" do not use this class.