### PR TITLE
Followup fixes for PR 270

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -21,16 +21,28 @@ function memberlite_register_blocks(): void {
 	foreach ( $memberlite_blocks as $memberlite_block ) {
 		register_block_type( get_template_directory() . '/build/blocks/' . $memberlite_block );
 	}
+}
+add_action( 'init', 'memberlite_register_blocks' );
 
+/**
+ * Localize editor-only data for the Nav Menu block.
+ *
+ * Runs on enqueue_block_editor_assets so the data is only attached in the block editor,
+ * not on every front-end request.
+ *
+ * @since TBD
+ * @return void
+ */
+function memberlite_enqueue_nav_menu_block_data(): void {
 	wp_localize_script(
 		'memberlite-nav-menu-editor-script',
-		'active_pmpro_plugins',
+		'memberliteBlockData',
 		array(
-			'nav_menu_plugin_active' => function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php' ),
+			'navMenuPluginActive' => function_exists( 'pmpro_is_plugin_active' ) && pmpro_is_plugin_active( 'pmpro-nav-menus/pmpro-nav-menus.php' ),
 		)
 	);
 }
-add_action( 'init', 'memberlite_register_blocks' );
+add_action( 'enqueue_block_editor_assets', 'memberlite_enqueue_nav_menu_block_data' );
 
 /**
  * Only allow Memberlite's Nav Menu block on the memberlite_header and memberlite_footer post types.
@@ -55,8 +67,13 @@ function memberlite_allowed_blocks( $allowed_block_types, $editor_context ) {
 		);
 	}
 
-	// Get all registered blocks if $allowed_block_types is not already set.
-	if ( ! is_array( $allowed_block_types ) || empty( $allowed_block_types ) ) {
+	// If another filter has explicitly disallowed all blocks, respect that.
+	if ( false === $allowed_block_types ) {
+		return $allowed_block_types;
+	}
+
+	// Default value (true) — expand into an explicit allowlist of currently registered blocks.
+	if ( ! is_array( $allowed_block_types ) ) {
 		$registered_blocks   = WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$allowed_block_types = array_keys( $registered_blocks );
 	}

--- a/src/blocks/member-info/block.json
+++ b/src/blocks/member-info/block.json
@@ -23,8 +23,8 @@
             "default": true
         }
     },
-	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
-	"render": "file:./render.php",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "render": "file:./render.php",
     "textdomain": "memberlite"
 }

--- a/src/blocks/nav-menu/block.json
+++ b/src/blocks/nav-menu/block.json
@@ -39,9 +39,9 @@
             "default": ""
         }
     },
-	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css",
-	"render": "file:./render.php",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php",
     "textdomain": "memberlite"
 }

--- a/src/blocks/nav-menu/edit.js
+++ b/src/blocks/nav-menu/edit.js
@@ -20,12 +20,10 @@ function Edit( { attributes, setAttributes } ) {
 	const [ menus, setMenus ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( '' );
-	// From wp_localize_script...
-	const navMenusAddOnActive = active_pmpro_plugins.nav_menu_plugin_active ?? false;
+	// From wp_localize_script — see memberlite_enqueue_nav_menu_block_data() in inc/blocks.php.
+	const navMenusAddOnActive = window.memberliteBlockData?.navMenuPluginActive ?? false;
 
 	useEffect( () => {
-		const labels = window.memberliteBlockData?.menuLocationLabels || {};
-
 		if ( ! navMenusAddOnActive ) {
 			Promise.all( [
 				apiFetch( { path: '/wp/v2/menus' } ),
@@ -51,7 +49,7 @@ function Edit( { attributes, setAttributes } ) {
 			] )
 				.then( ( [ fetchedLocations, fetchedMenus ] ) => {
 					const locationOptions = Object.entries( fetchedLocations ).map( ( [ slug, location ] ) => ( {
-						label: location.description || labels[ slug ] || slug,
+						label: location.description || slug,
 						value: `location:${ slug }`,
 					} ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hardens nav menu block: fix editor crash, stop front-end script leak
                                                                                                                                                    
- Rename localized JS global from `active_pmpro_plugins` to `memberliteBlockData` and use safe access (`window.…?.navMenuPluginActive ?? false`). Prevents a ReferenceError that crashed the editor whenever   the localize call failed to attach.
- Move `wp_localize_script` out of `memberlite_register_blocks()` (which runs on `init` for every request) into a new `memberlite_enqueue_nav_menu_block_data()` on `enqueue_block_editor_assets`, so the data only loads in the editor. 
- Tighten the `allowed_block_types_all` filter: explicit `false` (disallow-all) is now passed through instead of being silently expanded into a full allowlist.  
- Remove dead `memberliteBlockData.menuLocationLabels` lookup that was never localized; fall back to `location.description || slug`.  
- Normalize tab/space mixing in `nav-menu` and `member-info` block.json.  

One thing to note here, we're using `wp_localize_script` to send into editor whether the Nav Menus Add On is active. It's encoding PHP return `true` as the literal string '1' and PHP return `false` as the literal string '' (empty). 

So ,while our truthy / falsy in JS is working fine, if we wanted real booleans, we have to switch from `wp_localize_script` to `wp_add_inline_script` in `inc/blocks.php`. I don't think needed right now, just something Claude Code flagged - it was expecting the dev tools console test I ran for `window.memberliteBlockData` to show `{ navMenuPluginActive: true }` but I got `{ navMenuPluginActive: "1" }`.