### PR TITLE
Fix comments not displaying when comments are closed 

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -516,18 +516,17 @@ function memberlite_member_menu_cb( $args ) {
 add_filter( 'wp_nav_menu', 'do_shortcode', 11 );
 
 /* Exclude pings and trackbacks from the number of comments on a post. */
-function memberlite_comment_count( $count ) {
-	global $id;
-	$comment_count = 0;
-	$comments      = get_approved_comments( $id );
-	foreach ( $comments as $comment ) {
-		if ( $comment->comment_type === '' ) {
-			$comment_count++;
-		}
-	}
-	return $comment_count;
+function memberlite_comment_count( $count, $post_id ) {
+	return get_comments(
+		array(
+			'post_id' => $post_id,
+			'status'  => 'approve',
+			'type'    => 'comment',
+			'count'   => true,
+		)
+	);
 }
-add_filter( 'get_comments_number', 'memberlite_comment_count', 0 );
+add_filter( 'get_comments_number', 'memberlite_comment_count', 0, 2 );
 
 /* Custom loader for get_sidebar to allow templates and child themes to modify */
 function memberlite_get_sidebar( $name = null ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes the `get_comments_number` callback (`memberlite_comment_count()`) to correctly return the actual comment count, excluding pings and trackbacks.

The previous implementation had three issues:

- Used `global $id` instead of the `$post_id` passed by the `get_comments_number` filter, which could return a wrong or zero count depending on page context
- Only matched `comment_type = ''`, missing regular comments stored with `comment_type = 'comment'` in newer WordPress versions
- Loaded all comment objects via `get_approved_comments()` and looped to count them, when a single DB count query suffices

The fix uses `get_comments()` with `type='comment'`, which WordPress core normalises to `comment_type IN ('', 'comment')` internally, and `count=true` to return a scalar directly from the DB. The `add_filter` call is updated to pass arity `2` so the filter's `$post_id` argument is received by the callback.

The theme's template parts use a block like this to control whether comments are displayed.
```
if ( comments_open() || '0' != get_comments_number() ) :
	comments_template();
endif;
```
If comments were closed, `get_comments_number()` could still return '0' even in cases where there were comments, causing them to be hidden

### How to test the changes in this Pull Request:
1. Create a post.
2. Add a comment to the post.
3. Set _Discussion_ to _Closed_ on the post.
4. Observe that the comment is not displayed on the post page.
5. Apply PR.
6. Revisit post page and observe that comment displays.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed incorrect comment counts and comments not displaying when comments are closed.
