### PR TITLE
BUG FIX: Preserve default block allowlist when no blocks need filtering

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -69,12 +69,18 @@ function memberlite_allowed_blocks( $allowed_block_types, $editor_context ) {
 		);
 	}
 
+	// Nothing to disallow for this post type — return early and preserve the
+	// existing value (including `true`, which means "all blocks allowed").
+	if ( empty( $disallowed_blocks ) ) {
+		return $allowed_block_types;
+	}
+
 	// If another filter has explicitly disallowed all blocks, respect that.
 	if ( false === $allowed_block_types ) {
 		return $allowed_block_types;
 	}
 
-	// Default value (true) — expand into an explicit allowlist of currently registered blocks.
+	// Only expand `true` into an explicit array when we actually need to remove something.
 	if ( ! is_array( $allowed_block_types ) ) {
 		$registered_blocks   = WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$allowed_block_types = array_keys( $registered_blocks );
@@ -94,8 +100,8 @@ function memberlite_allowed_blocks( $allowed_block_types, $editor_context ) {
 		}
 	}
 
-	// Return the filtered list of allowed blocks
-	return $filtered_blocks;
+	// Return the filtered list of allowed blocks with sequential indices.
+	return array_values( $filtered_blocks );
 }
 add_filter( 'allowed_block_types_all', 'memberlite_allowed_blocks', 10, 2 );
 


### PR DESCRIPTION
## Summary

Fixes #293 — the `memberlite_allowed_blocks()` filter was converting the default value (`true`) into an explicit allowlist on every editor page load, causing late-registered blocks (like Yoast SEO Premium blocks) to be silently excluded from the inserter.

## The Problem

The function was:
1. Always expanding `true` → explicit array, even when `$disallowed_blocks` was empty
2. Taking a snapshot of registered blocks at filter run time
3. Excluding any blocks registered after that point (timing-dependent bug)
4. Running this expansion on every post type, even those with nothing to disallow

This affected third-party plugins whose blocks register on different hook timing than Memberlite's filter. Yoast SEO Premium blocks (`yoast-seo/table-of-contents`, etc.) disappeared from the inserter on standard posts/pages, though saved content still rendered fine.

## The Fix

- **Early return** when `$disallowed_blocks` is empty — preserves `true` as `true`
- **Lazy expansion** — only convert `true` → array when we actually need to filter something
- **Sequential indices** — added `array_values()` to prevent JS errors in block preferences screen

## What Changed

**Before:**
- Runs expensive `get_all_registered()` on every editor load, every post type
- Breaks late-registered blocks from plugins

**After:**
- For `memberlite_header` and `memberlite_footer` (where Memberlite's two blocks are disallowed), behavior unchanged
- For all other post types, returns `true` as-is → WordPress handles block registration normally
- Late-registered blocks work correctly

## Testing Steps

1. Install Memberlite 7.x + Yoast SEO Premium
2. Create a new Post (not header/footer CPT)
3. Open block inserter, search "Table of Contents"
4. **Expected:** Both core TOC block and Yoast's TOC block appear
5. **Actual (before fix):** Only core TOC appeared
6. **Actual (after fix):** Both blocks appear

## Notes

- Minimal, backward-compatible change
- No refactoring of surrounding code
- Preserves existing behavior for the two CPTs that need filtering
- Aligns with WordPress core's default behavior (`true` = "all blocks allowed")

🤖 Generated with [Claude Code](https://claude.com/claude-code)