### PR TITLE
Post 7.1 Minor Fixes

### DIFF
--- a/components/header/header-masthead.php
+++ b/components/header/header-masthead.php
@@ -15,10 +15,10 @@
 
 <?php
 // Check _memberlite_banner_show meta to determine if the masthead should display.
-// $args is passed from the header.php file via get_template_part()
+// $args are passed from the header.php file via get_template_part()
 $should_render_masthead = $args['should_render_masthead'];
 $memberlite_banner_show = apply_filters( 'memberlite_banner_show', $args['should_render_masthead'] );
-$banner_image_url = memberlite_get_masthead_banner_image_url();
+$banner_image_url       = memberlite_get_masthead_banner_image_url();
 
 if ( $should_render_masthead ) { ?>
 

--- a/components/header/header-masthead.php
+++ b/components/header/header-masthead.php
@@ -17,7 +17,6 @@
 // Check _memberlite_banner_show meta to determine if the masthead should display.
 // $args are passed from the header.php file via get_template_part()
 $should_render_masthead = $args['should_render_masthead'];
-$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $args['should_render_masthead'] );
 $banner_image_url       = memberlite_get_masthead_banner_image_url();
 
 if ( $should_render_masthead ) { ?>

--- a/components/header/header-masthead.php
+++ b/components/header/header-masthead.php
@@ -15,18 +15,12 @@
 
 <?php
 // Check _memberlite_banner_show meta to determine if the masthead should display.
-$memberlite_banner_post_id = get_queried_object_id();
-if ( empty( $memberlite_banner_post_id ) && ( is_home() || is_post_type_archive( 'post' ) ) ) {
-	$memberlite_banner_post_id = get_option( 'page_for_posts' );
-}
-$memberlite_banner_show = true;
-if ( ! empty( $memberlite_banner_post_id ) && get_post_meta( $memberlite_banner_post_id, '_memberlite_banner_show', true ) === '0' ) {
-	$memberlite_banner_show = false;
-}
-$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $memberlite_banner_show );
+// $args is passed from the header.php file via get_template_part()
+$should_render_masthead = $args['should_render_masthead'];
+$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $args['should_render_masthead'] );
 $banner_image_url = memberlite_get_masthead_banner_image_url();
 
-if ( ! empty( $memberlite_banner_show ) ) { ?>
+if ( $should_render_masthead ) { ?>
 
 	<?php do_action( 'memberlite_before_masthead_outer' ); ?>
 

--- a/components/page/content-page.php
+++ b/components/page/content-page.php
@@ -7,9 +7,10 @@
  *
  * @package Memberlite
  */
+$aria_attr = memberlite_should_masthead_render() ? ' aria-labelledby="page-title"' : '';
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> aria-labelledby="page-title">
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> <?php echo esc_attr( $aria_attr ); ?>>
 	<div class="entry-content">
 		<?php do_action( 'memberlite_before_content_page' ); ?>
 		<?php the_content(); ?>

--- a/components/page/content-page.php
+++ b/components/page/content-page.php
@@ -10,7 +10,7 @@
 $aria_attr = memberlite_should_masthead_render() ? ' aria-labelledby="page-title"' : '';
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> <?php echo esc_attr( $aria_attr ); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> <?php echo $aria_attr; ?>>
 	<div class="entry-content">
 		<?php do_action( 'memberlite_before_content_page' ); ?>
 		<?php the_content(); ?>

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -10,7 +10,7 @@
 
 global $memberlite_defaults;
 $post_class = get_post_type() === 'post' ? 'entry-header-grid' : '';
-$aria_attr = is_single() ? ' aria-labelledby="page-title"' : '';
+$aria_attr = is_single() && memberlite_should_masthead_render() ? ' aria-labelledby="page-title"' : '';
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class( $post_class ); ?><?php echo $aria_attr; ?>>

--- a/header.php
+++ b/header.php
@@ -65,4 +65,6 @@
 
 	<div id="content" class="site-content">
 
-		<?php get_template_part( 'components/header/header', 'masthead' ); ?>
+		<?php
+		$should_render_masthead = memberlite_should_masthead_render();
+		get_template_part( 'components/header/header', 'masthead', array( 'should_render_masthead' => $should_render_masthead ) ); ?>

--- a/header.php
+++ b/header.php
@@ -67,5 +67,4 @@
 
 		<?php
 		$should_render_masthead = memberlite_should_masthead_render();
-		$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $should_render_masthead );
-		get_template_part( 'components/header/header', 'masthead', array( 'should_render_masthead' => $memberlite_banner_show ) ); ?>
+		get_template_part( 'components/header/header', 'masthead', array( 'should_render_masthead' => $should_render_masthead ) ); ?>

--- a/header.php
+++ b/header.php
@@ -67,4 +67,5 @@
 
 		<?php
 		$should_render_masthead = memberlite_should_masthead_render();
-		get_template_part( 'components/header/header', 'masthead', array( 'should_render_masthead' => $should_render_masthead ) ); ?>
+		$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $should_render_masthead );
+		get_template_part( 'components/header/header', 'masthead', array( 'should_render_masthead' => $memberlite_banner_show ) ); ?>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -284,7 +284,7 @@ function memberlite_wp_ajax_dismiss_notice() {
 	// Get and validate the notice.
 	$notice = sanitize_key( wp_unslash( $_REQUEST['notice'] ?? '' ) );
 	if ( ! in_array( $notice, $notices, true ) ) {
-		wp_die( esc_html__( 'Invalid notice.', 'text-domain' ) );
+		wp_die( esc_html__( 'Invalid notice.', 'memberlite' ) );
 	}
 
 	// update option and leave

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Register custom post types for Memberlite
+ * Custom post types for Memberlite: registration and lifecycle hooks.
+ *
+ * Covers CPT registration, auto-title on save, and theme_mod/post-meta
+ * cleanup on permanent deletion for memberlite_header and memberlite_footer.
+ *
+ * @package Memberlite
  */
 
 /**
@@ -60,6 +65,18 @@ function memberlite_register_header_cpt(): void {
 	);
 }
 add_action( 'init', 'memberlite_register_header_cpt' );
+
+/*
+ * =========================================================================
+ * Auto-title on save
+ * =========================================================================
+ *
+ * WordPress assigns a bare numeric slug to posts saved without a title.
+ * These hooks replace that with a human-readable name ("Header 123") so
+ * that slugs stored in theme_mods and post meta remain meaningful. The
+ * remove/re-add pattern prevents the hook from triggering itself recursively
+ * when wp_update_post fires a second save_post.
+ */
 
 /**
  * Auto-generate a title and slug for memberlite_header posts saved without one.
@@ -205,8 +222,8 @@ add_action( 'save_post_memberlite_footer', 'memberlite_footer_auto_title', 10, 2
 /**
  * Clear theme_mods and per-page overrides referencing a deleted memberlite_header post.
  *
- * @since TBD
- * @param int $post_id The post being trashed or deleted.
+ * @since 7.1
+ * @param int $post_id The post ID being permanently deleted.
  * @return void
  */
 function memberlite_cleanup_header_assignment_on_delete( int $post_id ): void {
@@ -234,8 +251,8 @@ add_action( 'before_delete_post', 'memberlite_cleanup_header_assignment_on_delet
 /**
  * Clear theme_mods and per-page overrides referencing a deleted memberlite_footer post.
  *
- * @since TBD
- * @param int $post_id The post being trashed or deleted.
+ * @since 7.1
+ * @param int $post_id The post ID being permanently deleted.
  * @return void
  */
 function memberlite_cleanup_footer_assignment_on_delete( int $post_id ): void {

--- a/inc/page_banners.php
+++ b/inc/page_banners.php
@@ -598,3 +598,35 @@ function memberlite_get_masthead_banner_image_url() {
 
 	return false;
 }
+
+/**
+ * Get post banner/masthead ID
+ *
+ * @since TBD
+ * @return false|int|mixed|null
+ */
+function memberlite_get_banner_post_id() {
+	$memberlite_banner_post_id = get_queried_object_id();
+
+	if ( empty( $memberlite_banner_post_id ) && ( is_home() || is_post_type_archive( 'post' ) ) ) {
+		$memberlite_banner_post_id = get_option( 'page_for_posts' );
+	}
+
+	return $memberlite_banner_post_id;
+}
+/**
+ * Determine if the masthead banner should be rendered
+ *
+ * @since TBD
+ * @return bool
+ */
+function memberlite_should_masthead_render(): bool {
+	$memberlite_banner_show = true;
+	$memberlite_banner_post_id = memberlite_get_banner_post_id();
+
+	if ( ! empty( $memberlite_banner_post_id ) && get_post_meta( $memberlite_banner_post_id, '_memberlite_banner_show', true ) === '0' ) {
+		$memberlite_banner_show = false;
+	}
+
+	return $memberlite_banner_show;
+}

--- a/inc/page_banners.php
+++ b/inc/page_banners.php
@@ -600,7 +600,7 @@ function memberlite_get_masthead_banner_image_url() {
 }
 
 /**
- * Get post banner/masthead ID
+ * Get banner's post ID
  *
  * @since TBD
  * @return false|int|mixed|null

--- a/inc/page_banners.php
+++ b/inc/page_banners.php
@@ -603,7 +603,7 @@ function memberlite_get_masthead_banner_image_url() {
  * Get banner's post ID
  *
  * @since TBD
- * @return false|int|mixed|null
+ * @return mixed
  */
 function memberlite_get_banner_post_id() {
 	$memberlite_banner_post_id = get_queried_object_id();
@@ -627,6 +627,8 @@ function memberlite_should_masthead_render(): bool {
 	if ( ! empty( $memberlite_banner_post_id ) && get_post_meta( $memberlite_banner_post_id, '_memberlite_banner_show', true ) === '0' ) {
 		$memberlite_banner_show = false;
 	}
+
+	$memberlite_banner_show = apply_filters( 'memberlite_banner_show', $memberlite_banner_show, $memberlite_banner_post_id );
 
 	return $memberlite_banner_show;
 }

--- a/patterns/footer-04.php
+++ b/patterns/footer-04.php
@@ -94,7 +94,7 @@
 
 			<!-- wp:column {"width":"50%","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 			<div class="wp-block-column" style="flex-basis:50%">
-				<!-- wp:pmpro/login-form /-->
+				<!-- wp:pmpro/login-form {"style":{"elements":{"link":{"color":{"text":"var:preset|color|color-secondary"}}}},"textColor":"color-secondary"} /-->
 			</div>
 			<!-- /wp:column -->
 

--- a/src/scss/structure/_content.scss
+++ b/src/scss/structure/_content.scss
@@ -223,6 +223,7 @@
 .entry-footer .edit-link {
 	display: block;
 	width: max-content;
+	padding-top: var(--wp--preset--spacing--10);
 
 	a.post-edit-link {
 		@include tool-tip-base;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Added top padding to the wrapper around "edit" links throughout the theme (excludes the header/footer tooltips)
- Fixed missing text-domain in an existing function
- **A11y bug:** Resolves issue where `aria-labeledby` was referencing an ID in the masthead, but if the masthead is not present, it becomes an error. Added a helper to check whether the masthead should display. If it is displayed, then we apply the ARIA attribute.
- **A11y bug:** The Logout/Forgot Password links were not readable on the PMPro Login Form block in the Member Login Footer pattern. The pattern has been adjusted so that these links are always visible. (Contrast may still be an issue on some color schemes, but we have a separate ticket to dive into colors as it is a deeper task than just this item.) 
- Updated @since PHP docs where we missed them in 7.1

### How to test the changes in this Pull Request:

1. Confirm that the "Edit Post/Page" links have top padding
2. Use [Accessibility Cloud](https://www.accessibilitycloud.com/lite/) (or accessibility tool of choice) and run it on your local to confirm whether the `aria-labeledby` errors are gone whether there is a masthead or not. Confirm the masthead works as expected.
3. From the customizer, under "Footer", set up the "Member Login & Quick Links" footer pattern. If you don't have it set up in a footer post under Memberlite > Footers, you'll have to set up a post with that footer for testing. Once you've set it as your footer in Customizer, change the color schemes. Confirm that links are visible in the PMPro Login Form block regarding of the color schemes.

<img width="1330" height="1023" alt="image" src="https://github.com/user-attachments/assets/a8d56ca5-8698-48b7-90c2-3f8952272da8" />

**Example of resolved link color using the "Gotham" color scheme:**
<img width="1180" height="611" alt="image" src="https://github.com/user-attachments/assets/0b446774-530a-4770-8006-3d811ab62395" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added spacing for edit links, a corrected translation text-domain, and accessibility-related adjustments around masthead ARIA labeling and the PMPro login form block pattern.
