### PR TITLE
Remove function that restricts the member info and nav menu block to our memberlite_header/footer CPTs

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -45,61 +45,6 @@ function memberlite_enqueue_nav_menu_block_data(): void {
 add_action( 'enqueue_block_editor_assets', 'memberlite_enqueue_nav_menu_block_data' );
 
 /**
- * Only allow Memberlite's Nav Menu block on the memberlite_header and memberlite_footer post types.
- *
- * @param $allowed_block_types
- * @param $editor_context
- *
- * @since 7.1
- * @return array
- */
-function memberlite_allowed_blocks( $allowed_block_types, $editor_context ) {
-	$disallowed_blocks = array();
-
-	if ( ! isset( $editor_context->post->post_type ) ) {
-		return $allowed_block_types;
-	}
-
-	$post_type = $editor_context->post->post_type;
-
-	if ( ! in_array( $post_type, array( 'memberlite_footer', 'memberlite_header' ), true ) ) {
-		$disallowed_blocks = array(
-			'memberlite/nav-menu',
-			'memberlite/member-info',
-		);
-	}
-
-	// If another filter has explicitly disallowed all blocks, respect that.
-	if ( false === $allowed_block_types ) {
-		return $allowed_block_types;
-	}
-
-	// Default value (true) — expand into an explicit allowlist of currently registered blocks.
-	if ( ! is_array( $allowed_block_types ) ) {
-		$registered_blocks   = WP_Block_Type_Registry::get_instance()->get_all_registered();
-		$allowed_block_types = array_keys( $registered_blocks );
-	}
-
-	// Create a new array for the allowed blocks.
-	$filtered_blocks = array();
-
-	// Loop through each block in the allowed blocks list.
-	foreach ( $allowed_block_types as $block ) {
-
-		// Check if the block is not in the disallowed blocks list.
-		if ( ! in_array( $block, $disallowed_blocks, true ) ) {
-
-			// If it's not disallowed, add it to the filtered list.
-			$filtered_blocks[] = $block;
-		}
-	}
-
-	// Return the filtered list of allowed blocks
-	return $filtered_blocks;
-}
-add_filter( 'allowed_block_types_all', 'memberlite_allowed_blocks', 10, 2 );
-
-/**
  * Enqueue JS for custom block inserter icon for our Memberlite block category.
  *
  * @since 7.1


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Option 1 fix for Issue #293, slated for 7.1.1 release. The function was causing third party blocks to be dropped from the block inserter.

### How to test the changes in this Pull Request:

Confirm that the "Member Info" and "Nav Menu" blocks still appear under the "Theme" category and "Memberlite" collection in the block inserter. These blocks will be available on all post types now, not just `memberlite_header` and `memberlite_footer`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed Memberlite’s allowed_block_types_all filter that attempted to scope the memberlite/nav-menu and memberlite/member-info blocks to the memberlite_header/memberlite_footer CPTs, resolving the reported compatibility issue where JS-only (client-registered) third-party blocks disappeared from the inserter.
