### PR TITLE
Add custom admin column for header variations

### DIFF
--- a/docs/variations.md
+++ b/docs/variations.md
@@ -12,10 +12,11 @@ This document covers the variations system introduced in Memberlite 7.1. Both he
    - [Per-Page Override (Pages Only)](#per-page-override-pages-only)
    - [Sticky Option](#sticky-option)
    - [Header Patterns](#header-patterns)
+   - [Admin List Table](#admin-list-table)
 4. [Footer Variations](#footer-variations)
    - [Resolver Priority Chain](#resolver-priority-chain)
    - [Customizer Controls](#customizer-controls-1)
-   - [The Global Sentinel Value](#the-global-sentinel-value)
+   - [Special Reserved Values](#special-reserved-values)
    - [Per-Page Override (Pages Only)](#per-page-override-pages-only)
    - [Footer Patterns](#footer-patterns)
    - [Transient Cache](#transient-cache)
@@ -121,6 +122,17 @@ Starter header designs are registered as block patterns scoped to the `memberlit
 
 See [patterns.md](patterns.md) for general pattern authoring guidelines.
 
+### Admin List Table
+
+The `memberlite_header` list table (Memberlite > Headers) includes a **"Used By"** column showing where each header is currently assigned.
+
+`memberlite_get_header_assignments( $post_name )` in `inc/admin.php` checks:
+
+1. **The global theme mod** — `memberlite_default_header_slug`. A match produces a linked label ("Global Header") that deep-links into the Customizer at the matching control.
+2. **Per-page post meta** — a direct database query for all pages with `_memberlite_header_override` set to this header's slug. Displays "1 page override" (linked to that page's edit screen) or "N page overrides" (unlinked) as appropriate.
+
+If a header has no assignments, the column shows `—`.
+
 ---
 
 ## Footer Variations
@@ -134,7 +146,7 @@ See [patterns.md](patterns.md) for general pattern authoring guidelines.
 3. **Global theme mod** (`memberlite_global_footer_slug`) — the site-wide default, used when the location mod is set to inherit.
 4. **Default footer** — rendered when the resolved value is `'0'`.
 
-If the resolved post_name no longer exists (e.g., the footer post was deleted), the resolver falls back to `'0'` rather than rendering nothing.
+If the resolved `post_name` no longer exists (e.g., the footer post was deleted), the resolver falls back to `'0'` rather than rendering nothing.
 
 `footer.php` wraps the footer in `<footer id="colophon">` with two possible classes:
 - `site-footer site-footer-{post_name}` — when a CPT footer is active
@@ -161,21 +173,22 @@ A **"Manage Footers"** link in the panel navigates directly to the `memberlite_f
 
 #### How choices are built
 
-`memberlite_get_footer_variations()` returns only published CPT footer posts as a `slug => title` array, alphabetical by title. It never includes sentinels — each consumer adds its own:
+`memberlite_get_footer_variations()` returns only published CPT footer posts as a `slug => title` array, alphabetical by title. It does not include placeholder options like "— Default —" or "— Use Global Footer —" — each caller prepends whichever placeholder is appropriate for its context:
 
 - **Customizer global control** — always prepends `'0' => '— Default —'` alongside any CPT footers.
 - **Customizer location controls** — prepend `'memberlite-global-footer' => '— Use Global Footer —'`.
 - **Editor sidebar** — prepends `'' => '— Use Global Footer —'`.
 
-### The Global Sentinel Value
+### Special Reserved Values
 
-Location-specific footer controls use the string `'memberlite-global-footer'` as a sentinel meaning "inherit from the global setting." This is distinct from `'0'` (default) and from any real footer post_name.
+The footer resolver recognises three categories of stored value:
 
-- **`'memberlite-global-footer'`** → read `memberlite_global_footer_slug` and use that value
-- **`'0'`** → use the default widget-area footer (only reachable via the global control)
+- **`'memberlite-global-footer'`** → used by location-specific controls to mean "inherit from the global setting"; read `memberlite_global_footer_slug` and use that value instead
+- **`'0'`** → use the default widget-area footer (only selectable via the global control)
 - **any other string** → a footer post_name; look up and render that post
 
-The sentinel is namespaced to avoid accidental collision with a user-created footer slug. The auto-title function generates slugs like `footer-{post_id}`, so natural collisions are not possible.
+The `'memberlite-global-footer'` string is deliberately namespaced to avoid any collision with a real footer slug. The auto-title function generates slugs like `footer-{post_id}`, so a natural collision is not possible.
+
 
 ### Per-Page Override (Pages Only)
 
@@ -230,8 +243,6 @@ The `memberlite_footer` list table (Memberlite > Footers) includes a **"Used By"
 
 If a footer has no assignments, the column shows `—`.
 
-The header list table does not have an equivalent "Used By" column, since headers have only one global setting.
-
 #### Admin navigation
 
 The footer CPT is surfaced under **Memberlite > Footers** and the header CPT under **Memberlite > Headers** in the admin menu. Filters on `parent_file` and `submenu_file` keep the correct menu items highlighted when viewing the list table or editing a single variation post.
@@ -240,38 +251,37 @@ The footer CPT is surfaced under **Memberlite > Footers** and the header CPT und
 
 ## Key Differences at a Glance
 
-| Feature | Header | Footer |
-|---|---|---|
-| CPT slug | `memberlite_header` | `memberlite_footer` |
-| Global setting | `memberlite_default_header_slug` | `memberlite_global_footer_slug` |
-| Location-specific settings | None | 3 (posts, pages, archives) |
-| Location sentinel value | N/A | `'memberlite-global-footer'` |
-| Per-page override | Yes (`_memberlite_header_override`, pages only) | Yes (`_memberlite_footer_override`, pages only) |
+| Feature | Header                                                    | Footer |
+|---|-----------------------------------------------------------|---|
+| CPT slug | `memberlite_header`                                       | `memberlite_footer` |
+| Global setting | `memberlite_default_header_slug`                          | `memberlite_global_footer_slug` |
+| Location-specific settings | None                                                      | 3 (posts, pages, archives) |
+| Per-page override | Yes (`_memberlite_header_override`, pages only)           | Yes (`_memberlite_footer_override`, pages only) |
 | Sticky option | Yes (`_memberlite_header_sticky` post meta per variation) | No |
-| Default sticky | `sticky_nav` theme_mod (default header only) | N/A |
-| Starter patterns | 6 (`header-01` – `header-06`) | 8 (`footer-*.php`) |
-| Transient cache | Yes (`memberlite_header_variations`, 12 h) | Yes (`memberlite_footer_variations`, 12 h) |
-| "Used By" admin column | No | Yes |
-| Admin menu item | Memberlite > Headers | Memberlite > Footers |
+| Default sticky | `sticky_nav` theme_mod (default header only)              | N/A |
+| Starter patterns | 6 (`header-*.php`)                          | 8 (`footer-*.php`) |
+| Transient cache | Yes (`memberlite_header_variations`, 12 h)                | Yes (`memberlite_footer_variations`, 12 h) |
+| "Used By" admin column | Yes                                                       | Yes |
+| Admin menu item | Memberlite > Headers                                      | Memberlite > Footers |
 
 ---
 
 ## Key Files
 
-| File | Purpose |
-|---|---|
-| `inc/variations.php` | Resolver, renderer, get-variations, cache, and active_callback functions for both systems |
-| `inc/custom-post-types.php` | CPT registration and auto-title hooks for both CPTs |
-| `inc/customizer.php` | Customizer controls for both header and footer variation settings |
-| `inc/admin.php` | Admin menu registration, menu highlight filters, footer "Used By" column |
-| `inc/editor-settings.php` | Post meta registration (`_memberlite_header_sticky`, `_memberlite_header_override`, `_memberlite_footer_override`, `_memberlite_hide_footer`), editor JS enqueue |
-| `inc/updates.php` | `memberlite_checkForUpdates()` — version migration runner |
-| `header.php` | Calls header resolver and renderer; handles sticky wrapper; falls back to default |
-| `footer.php` | Calls footer resolver and renderer; falls back to default footer |
-| `components/footer/variation-default.php` | Default footer template (widget areas, navigation, site info) |
-| `patterns/header-01.php` – `header-06.php` | Six starter header patterns scoped to the CPT |
-| `patterns/footer-*.php` | Eight starter footer patterns scoped to the CPT |
+| File                                     | Purpose                                                                                                                                                          |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inc/variations.php`                     | Resolver, renderer, get-variations, cache, and active_callback functions for both systems                                                                        |
+| `inc/custom-post-types.php`              | CPT registration and auto-title hooks for both CPTs                                                                                                              |
+| `inc/customizer.php`                     | Customizer controls for both header and footer variation settings                                                                                                |
+| `inc/admin.php`                          | Admin menu registration, menu highlight filters, header and footer "Used By" columns                                                                             |
+| `inc/editor-settings.php`                | Post meta registration (`_memberlite_header_sticky`, `_memberlite_header_override`, `_memberlite_footer_override`, `_memberlite_hide_footer`), editor JS enqueue |
+| `inc/updates.php`                        | `memberlite_checkForUpdates()` — version migration runner                                                                                                        |
+| `header.php`                             | Calls header resolver and renderer; handles sticky wrapper; falls back to default                                                                                |
+| `footer.php`                             | Calls footer resolver and renderer; falls back to default footer                                                                                                 |
+| `components/footer/variation-default.php` | Default footer template (widget areas, navigation, site info)                                                                                                    |
+| `patterns/header-*.php` | Starter header patterns scoped to the CPT                                                                                                                        |
+| `patterns/footer-*.php`                  | Starter footer patterns scoped to the CPT                                                                                                                        |
 
 ---
 
-**Last Updated**: 2026-05-01
+**Last Updated**: 2026-05-11

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -204,18 +204,18 @@ function memberlite_get_header_assignments( string $post_name ): array {
 }
 
 /**
- * Add a "Used By" column to the header/footer CPT list table.
+ * Add a "Used By" column to a variation CPT list table.
  *
  * @since 7.1
  * @param array $columns Existing columns.
  * @return array Modified columns.
  */
-function memberlite_header_footer_add_used_by_column( array $columns ): array {
+function memberlite_variation_add_used_by_column( array $columns ): array {
 	$columns['memberlite_used_by'] = __( 'Used By', 'memberlite' );
 	return $columns;
 }
-add_filter( 'manage_memberlite_footer_posts_columns', 'memberlite_header_footer_add_used_by_column' );
-add_filter( 'manage_memberlite_header_posts_columns', 'memberlite_header_footer_add_used_by_column' );
+add_filter( 'manage_memberlite_footer_posts_columns', 'memberlite_variation_add_used_by_column' );
+add_filter( 'manage_memberlite_header_posts_columns', 'memberlite_variation_add_used_by_column' );
 
 /**
  * Render the "Used By" column content for footer posts.
@@ -237,7 +237,7 @@ function memberlite_footer_render_used_by_column( string $column, int $post_id )
 
 	$assignments = memberlite_get_footer_assignments( $post->post_name );
 
-	memberlite_display_formatted_header_footer_assignments( $assignments );
+	memberlite_display_formatted_variation_assignments( $assignments );
 }
 add_action( 'manage_memberlite_footer_posts_custom_column', 'memberlite_footer_render_used_by_column', 10, 2 );
 
@@ -261,19 +261,19 @@ function memberlite_header_render_used_by_column( string $column, int $post_id )
 
 	$assignments = memberlite_get_header_assignments( $post->post_name );
 
-	memberlite_display_formatted_header_footer_assignments( $assignments );
+	memberlite_display_formatted_variation_assignments( $assignments );
 }
 add_action( 'manage_memberlite_header_posts_custom_column', 'memberlite_header_render_used_by_column', 10, 2 );
 
 /**
- * Set up and format links in the "Used By" column for header and footer posts.
+ * Set up and format links in the "Used By" column for variation posts.
  *
  * @since TBD
- * @param array $assignments Array of header/footer assignment data to display.
+ * @param array $assignments Array of variation assignment data to display.
  *
  * @return void
  */
-function memberlite_display_formatted_header_footer_assignments( array $assignments ) {
+function memberlite_display_formatted_variation_assignments( array $assignments ) {
 	if ( empty( $assignments ) ) {
 		echo '<span aria-label="' . esc_attr__( 'Not assigned', 'memberlite' ) . '">&#8212;</span>';
 		return;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -269,11 +269,11 @@ add_action( 'manage_memberlite_header_posts_custom_column', 'memberlite_header_r
  * Set up and format links in the "Used By" column for header and footer posts.
  *
  * @since TBD
- * @param $assignments
+ * @param array $assignments Array of header/footer assignment data to display.
  *
  * @return void
  */
-function memberlite_display_formatted_header_footer_assignments( $assignments ) {
+function memberlite_display_formatted_header_footer_assignments( array $assignments ) {
 	if ( empty( $assignments ) ) {
 		echo '<span aria-label="' . esc_attr__( 'Not assigned', 'memberlite' ) . '">&#8212;</span>';
 		return;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -105,6 +105,46 @@ function memberlite_footer_cpt_submenu_highlight( $submenu_file ) {
 add_filter( 'submenu_file', 'memberlite_footer_cpt_submenu_highlight' );
 
 /**
+ * Get page-level override assignments for a header or footer variation post.
+ *
+ * @since 7.1
+ * @param string $meta_key  The post meta key used for per-page overrides.
+ * @param string $post_name The post_name of the variation post.
+ * @return array Human-readable assignment entries, empty if none found.
+ */
+function memberlite_get_page_override_assignments( string $meta_key, string $post_name ): array {
+	global $wpdb;
+
+	$assignments = array();
+
+	$override_post_ids = $wpdb->get_col( $wpdb->prepare(
+		"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s",
+		$meta_key,
+		$post_name
+	) );
+
+	$page_count = count( $override_post_ids );
+
+	if ( 1 === $page_count ) {
+		$assignments[] = array(
+			'label' => __( '1 page override', 'memberlite' ),
+			'url'   => get_edit_post_link( (int) $override_post_ids[0] ),
+		);
+	} elseif ( $page_count > 1 ) {
+		$assignments[] = array(
+			'label' => sprintf(
+				/* translators: %d: number of pages with this variation assigned via post meta override */
+				__( '%d page overrides', 'memberlite' ),
+				$page_count
+			),
+			'url'   => null,
+		);
+	}
+
+	return $assignments;
+}
+
+/**
  * Get the locations where a footer post is currently assigned.
  *
  * Checks the four footer theme mods and any per-page override post meta.
@@ -116,8 +156,6 @@ add_filter( 'submenu_file', 'memberlite_footer_cpt_submenu_highlight' );
  * @return array Human-readable assignment labels, empty if unassigned.
  */
 function memberlite_get_footer_assignments( string $post_name ): array {
-	global $wpdb;
-
 	$assignments = array();
 
 	$theme_mod_controls = array(
@@ -136,36 +174,21 @@ function memberlite_get_footer_assignments( string $post_name ): array {
 		}
 	}
 
-	// Get per-page override post IDs via a direct meta query.
-	$override_post_ids = $wpdb->get_col( $wpdb->prepare(
-		"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_memberlite_footer_override' AND meta_value = %s",
-		$post_name
-	) );
-
-	$page_count = count( $override_post_ids );
-
-	if ( 1 === $page_count ) {
-		$assignments[] = array(
-			'label' => __( '1 page override', 'memberlite' ),
-			'url'   => get_edit_post_link( (int) $override_post_ids[0] ),
-		);
-	} elseif ( $page_count > 1 ) {
-		$assignments[] = array(
-			'label' => sprintf(
-				/* translators: %d: number of pages with this footer assigned via post meta override */
-				__( '%d page overrides', 'memberlite' ),
-				$page_count
-			),
-			'url'   => null,
-		);
-	}
-
-	return $assignments;
+	return array_merge( $assignments, memberlite_get_page_override_assignments( '_memberlite_footer_override', $post_name ) );
 }
 
+/**
+ * Get the locations where a header post is currently assigned.
+ *
+ * Checks the global header theme mod and any per-page override post meta.
+ * Returns human-readable labels used by the list table column and the
+ * trash row action prevention.
+ *
+ * @since 7.1
+ * @param string $post_name The post_name of the memberlite_header post.
+ * @return array Human-readable assignment labels, empty if unassigned.
+ */
 function memberlite_get_header_assignments( string $post_name ): array {
-	global $wpdb;
-
 	$assignments = array();
 
 	$mod_key = 'memberlite_default_header_slug';
@@ -177,31 +200,7 @@ function memberlite_get_header_assignments( string $post_name ): array {
 		);
 	}
 
-	// Get per-page override post IDs via a direct meta query.
-	$override_post_ids = $wpdb->get_col( $wpdb->prepare(
-		"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_memberlite_header_override' AND meta_value = %s",
-		$post_name
-	) );
-
-	$page_count = count( $override_post_ids );
-
-	if ( 1 === $page_count ) {
-		$assignments[] = array(
-			'label' => __( '1 page override', 'memberlite' ),
-			'url'   => get_edit_post_link( (int) $override_post_ids[0] ),
-		);
-	} elseif ( $page_count > 1 ) {
-		$assignments[] = array(
-			'label' => sprintf(
-			/* translators: %d: number of pages with this footer assigned via post meta override */
-				__( '%d page overrides', 'memberlite' ),
-				$page_count
-			),
-			'url'   => null,
-		);
-	}
-
-	return $assignments;
+	return array_merge( $assignments, memberlite_get_page_override_assignments( '_memberlite_header_override', $post_name ) );
 }
 
 /**
@@ -266,6 +265,14 @@ function memberlite_header_render_used_by_column( string $column, int $post_id )
 }
 add_action( 'manage_memberlite_header_posts_custom_column', 'memberlite_header_render_used_by_column', 10, 2 );
 
+/**
+ * Set up and format links in the "Used By" column for header and footer posts.
+ *
+ * @since TBD
+ * @param $assignments
+ *
+ * @return void
+ */
 function memberlite_display_formatted_header_footer_assignments( $assignments ) {
 	if ( empty( $assignments ) ) {
 		echo '<span aria-label="' . esc_attr__( 'Not assigned', 'memberlite' ) . '">&#8212;</span>';

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -107,7 +107,7 @@ add_filter( 'submenu_file', 'memberlite_footer_cpt_submenu_highlight' );
 /**
  * Get page-level override assignments for a header or footer variation post.
  *
- * @since 7.1
+ * @since TBD
  * @param string $meta_key  The post meta key used for per-page overrides.
  * @param string $post_name The post_name of the variation post.
  * @return array Human-readable assignment entries, empty if none found.
@@ -184,7 +184,7 @@ function memberlite_get_footer_assignments( string $post_name ): array {
  * Returns human-readable labels used by the list table column and the
  * trash row action prevention.
  *
- * @since 7.1
+ * @since TBD
  * @param string $post_name The post_name of the memberlite_header post.
  * @return array Human-readable assignment labels, empty if unassigned.
  */

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -163,18 +163,60 @@ function memberlite_get_footer_assignments( string $post_name ): array {
 	return $assignments;
 }
 
+function memberlite_get_header_assignments( string $post_name ): array {
+	global $wpdb;
+
+	$assignments = array();
+
+	$mod_key = 'memberlite_default_header_slug';
+
+	if ( get_theme_mod( $mod_key ) === $post_name ) {
+		$assignments[] = array(
+			'label' => __( 'Global Header', 'memberlite' ),
+			'url'   => add_query_arg( array( 'autofocus[control]' => $mod_key ), admin_url( 'customize.php' ) ),
+		);
+	}
+
+	// Get per-page override post IDs via a direct meta query.
+	$override_post_ids = $wpdb->get_col( $wpdb->prepare(
+		"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_memberlite_header_override' AND meta_value = %s",
+		$post_name
+	) );
+
+	$page_count = count( $override_post_ids );
+
+	if ( 1 === $page_count ) {
+		$assignments[] = array(
+			'label' => __( '1 page override', 'memberlite' ),
+			'url'   => get_edit_post_link( (int) $override_post_ids[0] ),
+		);
+	} elseif ( $page_count > 1 ) {
+		$assignments[] = array(
+			'label' => sprintf(
+			/* translators: %d: number of pages with this footer assigned via post meta override */
+				__( '%d page overrides', 'memberlite' ),
+				$page_count
+			),
+			'url'   => null,
+		);
+	}
+
+	return $assignments;
+}
+
 /**
- * Add a "Used By" column to the footer CPT list table.
+ * Add a "Used By" column to the header/footer CPT list table.
  *
  * @since 7.1
  * @param array $columns Existing columns.
  * @return array Modified columns.
  */
-function memberlite_footer_add_used_by_column( array $columns ): array {
+function memberlite_header_footer_add_used_by_column( array $columns ): array {
 	$columns['memberlite_used_by'] = __( 'Used By', 'memberlite' );
 	return $columns;
 }
-add_filter( 'manage_memberlite_footer_posts_columns', 'memberlite_footer_add_used_by_column' );
+add_filter( 'manage_memberlite_footer_posts_columns', 'memberlite_header_footer_add_used_by_column' );
+add_filter( 'manage_memberlite_header_posts_columns', 'memberlite_header_footer_add_used_by_column' );
 
 /**
  * Render the "Used By" column content for footer posts.
@@ -189,12 +231,42 @@ function memberlite_footer_render_used_by_column( string $column, int $post_id )
 	}
 
 	$post = get_post( $post_id );
+
 	if ( ! $post ) {
 		return;
 	}
 
 	$assignments = memberlite_get_footer_assignments( $post->post_name );
 
+	memberlite_display_formatted_header_footer_assignments( $assignments );
+}
+add_action( 'manage_memberlite_footer_posts_custom_column', 'memberlite_footer_render_used_by_column', 10, 2 );
+
+/**
+ * Render the "Used By" column content for header posts.
+ *
+ * @since TBD
+ * @param string $column  The column name.
+ * @param int    $post_id The post ID.
+ */
+function memberlite_header_render_used_by_column( string $column, int $post_id ): void {
+	if ( 'memberlite_used_by' !== $column ) {
+		return;
+	}
+
+	$post = get_post( $post_id );
+
+	if ( ! $post ) {
+		return;
+	}
+
+	$assignments = memberlite_get_header_assignments( $post->post_name );
+
+	memberlite_display_formatted_header_footer_assignments( $assignments );
+}
+add_action( 'manage_memberlite_header_posts_custom_column', 'memberlite_header_render_used_by_column', 10, 2 );
+
+function memberlite_display_formatted_header_footer_assignments( $assignments ) {
 	if ( empty( $assignments ) ) {
 		echo '<span aria-label="' . esc_attr__( 'Not assigned', 'memberlite' ) . '">&#8212;</span>';
 		return;
@@ -210,7 +282,6 @@ function memberlite_footer_render_used_by_column( string $column, int $post_id )
 	}
 	echo implode( ', ', $parts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
-add_action( 'manage_memberlite_footer_posts_custom_column', 'memberlite_footer_render_used_by_column', 10, 2 );
 
 /**
  * Show an action button for the specified plugin

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -118,7 +118,7 @@ function memberlite_get_page_override_assignments( string $meta_key, string $pos
 	$assignments = array();
 
 	$override_post_ids = $wpdb->get_col( $wpdb->prepare(
-		"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s",
+		"SELECT pm.post_id FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = %s AND pm.meta_value = %s AND p.post_status = 'publish'",
 		$meta_key,
 		$post_name
 	) );
@@ -273,7 +273,7 @@ add_action( 'manage_memberlite_header_posts_custom_column', 'memberlite_header_r
  *
  * @return void
  */
-function memberlite_display_formatted_variation_assignments( array $assignments ) {
+function memberlite_display_formatted_variation_assignments( array $assignments ): void {
 	if ( empty( $assignments ) ) {
 		echo '<span aria-label="' . esc_attr__( 'Not assigned', 'memberlite' ) . '">&#8212;</span>';
 		return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Mirrors the logic we had for the footer variations where we added a custom admin column to display where that footer post is being used -- for the headers. (e.g. Global Footer, Global Header, Pages, 1 page override and so on.) Some minor re-factor on existing functions since both variations share some logic.

Updated the `docs/variations.md` documentation to include these new additions and for clarity. (Removed a lot of the "sentinel" wording that seemed confusing.)

**Note:** Any `@since` TBD versions will be updated when we're ready to push a release.

### How to test the changes in this Pull Request:

Confirm that the header posts under Memberlite > Headers have a "Used By" column. Confirm that the column accurately shows which header is assigned as either the "Global Header" (customizer) or a "1 page override" (template setting in a post).

<img width="907" height="402" alt="image" src="https://github.com/user-attachments/assets/0097163c-23db-4144-b158-db7fd4bebe47" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adds a “Used By” admin list-table column for `memberlite_header` variations (matching the existing footer behavior) and refactors shared “assignment location” logic so both header and footer variations can report where they’re in use.
