### PR TITLE
Resolving font color clash on footer-04; adding group with 0 block spacing to link lists

### DIFF
--- a/patterns/footer-04.php
+++ b/patterns/footer-04.php
@@ -16,8 +16,8 @@
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
 
-	<!-- wp:group {"align":"wide","className":"footer-variation-04","style":{"border":{"radius":{"topLeft":"8px","topRight":"8px","bottomLeft":"8px","bottomRight":"8px"},"width":"1px"},"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"footer-widgets-background","borderColor":"borders","textColor":"footer-widgets","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide footer-variation-04 has-footer-widgets-color has-footer-widgets-background-background-color has-text-color has-background has-link-color has-border-color has-borders-border-color" style="border-width:1px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"align":"wide","className":"footer-variation-04","style":{"border":{"radius":{"topLeft":"8px","topRight":"8px","bottomLeft":"8px","bottomRight":"8px"},"width":"1px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"footer-widgets-background","borderColor":"borders","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide footer-variation-04 has-footer-widgets-background-background-color has-background has-border-color has-borders-border-color" style="border-width:1px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
 
 		<!-- wp:columns {"align":"wide"} -->
 		<div class="wp-block-columns alignwide">
@@ -25,34 +25,42 @@
 			<!-- wp:column {"width":"25%","textColor":"footer-widgets","style":{"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}},"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 			<div class="wp-block-column has-footer-widgets-color has-text-color has-link-color" style="flex-basis:25%">
 
-				<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
-				<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Member Area', 'memberlite' ); ?></strong></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
+					<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Member Area', 'memberlite' ); ?></strong></p>
+					<!-- /wp:paragraph -->
 
-				<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-				<ul class="wp-block-list is-style-plain">
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Membership Levels', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Join Now', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Member Login', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'My Account', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-				</ul>
-				<!-- /wp:list -->
+					<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
+					<ul class="wp-block-list is-style-plain">
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Membership Levels', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Join Now', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Member Login', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'My Account', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+					</ul>
+					<!-- /wp:list -->
+				</div>
+				<!-- /wp:group -->
 
 				<!-- wp:spacer {"height":"10px"} -->
 				<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
-				<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
-				<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Support', 'memberlite' ); ?></strong></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
+					<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Support', 'memberlite' ); ?></strong></p>
+					<!-- /wp:paragraph -->
 
-				<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-				<ul class="wp-block-list is-style-plain">
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Contact Us', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Help Center', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Refund Policy', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-				</ul>
-				<!-- /wp:list -->
+					<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
+					<ul class="wp-block-list is-style-plain">
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Contact Us', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Help Center', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Refund Policy', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+					</ul>
+					<!-- /wp:list -->
+				</div>
+				<!-- /wp:group -->
 
 			</div>
 			<!-- /wp:column -->
@@ -60,41 +68,49 @@
 			<!-- wp:column {"width":"25%","textColor":"footer-widgets","style":{"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}},"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 			<div class="wp-block-column has-footer-widgets-color has-text-color has-link-color" style="flex-basis:25%">
 
-				<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
-				<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Quick Links', 'memberlite' ); ?></strong></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
+					<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'Quick Links', 'memberlite' ); ?></strong></p>
+					<!-- /wp:paragraph -->
 
-				<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-				<ul class="wp-block-list is-style-plain">
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Courses & Training', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Community', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Blog', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Events', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-				</ul>
-				<!-- /wp:list -->
+					<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
+					<ul class="wp-block-list is-style-plain">
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Courses & Training', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Community', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Blog', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Events', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+					</ul>
+					<!-- /wp:list -->
+				</div>
+				<!-- /wp:group -->
 
 				<!-- wp:spacer {"height":"10px"} -->
 				<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
-				<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
-				<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'About Us', 'memberlite' ); ?></strong></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"letterSpacing":"-0.03em"}},"textColor":"footer-widgets"} -->
+					<p class="has-footer-widgets-color has-text-color" style="letter-spacing:-0.03em"><strong><?php esc_html_e( 'About Us', 'memberlite' ); ?></strong></p>
+					<!-- /wp:paragraph -->
 
-				<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-				<ul class="wp-block-list is-style-plain">
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Our Story', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Who We Help', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-					<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Our Team', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
-				</ul>
-				<!-- /wp:list -->
+					<!-- wp:list {"className":"is-style-plain","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
+					<ul class="wp-block-list is-style-plain">
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Our Story', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Who We Help', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+						<!-- wp:list-item {"style":{"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} --><li style="margin-top:4px;margin-bottom:4px"><a href="#"><?php esc_html_e( 'Our Team', 'memberlite' ); ?></a></li><!-- /wp:list-item -->
+					</ul>
+					<!-- /wp:list -->
+				</div>
+				<!-- /wp:group -->
 
 			</div>
 			<!-- /wp:column -->
 
 			<!-- wp:column {"width":"50%","style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 			<div class="wp-block-column" style="flex-basis:50%">
-				<!-- wp:pmpro/login-form {"style":{"elements":{"link":{"color":{"text":"var:preset|color|color-secondary"}}}},"textColor":"color-secondary"} /-->
+				<!-- wp:pmpro/login-form /-->
 			</div>
 			<!-- /wp:column -->
 
@@ -105,8 +121,8 @@
 		<hr class="wp-block-separator alignwide has-text-color has-borders-color has-alpha-channel-opacity has-borders-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
 		<!-- /wp:separator -->
 
-		<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
-		<div class="wp-block-group alignwide">
+		<!-- wp:group {"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|footer-widgets"}}},"spacing":{"blockGap":"var:preset|spacing|20"}},"textColor":"footer-widgets","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
+		<div class="wp-block-group alignwide has-footer-widgets-color has-text-color has-link-color">
 
 			<!-- wp:group {"style":{"spacing":{"blockGap":"5px"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
 			<div class="wp-block-group">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removed the text color overrides from the PMPro - Log In form side. That will leave all color of that up to PMPro settings and/or the Memberlite site's option to override.

Text and link color is now only applied on the text columns.

Also added group blocks so the "link list title" and list of links are more tightly spaced.

Screenshots:

<img width="1261" height="662" alt="Screenshot 2026-05-21 at 5 34 53 AM" src="https://github.com/user-attachments/assets/0ad9d3dc-9ede-4a97-aeaf-68378142a703" />

<img width="1227" height="652" alt="Screenshot 2026-05-21 at 5 35 02 AM" src="https://github.com/user-attachments/assets/92170cb2-1b2d-4dec-966d-aca078d8b2ad" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?