### PR TITLE
Clickable featured images, new 16x9 image size, outline style button fix

### DIFF
--- a/components/post/content-grid.php
+++ b/components/post/content-grid.php
@@ -14,9 +14,9 @@ global $memberlite_defaults; ?>
 	<a class="post-thumbnail-link" href="<?php echo esc_url( get_permalink() ); ?>">
 		<?php
 			// Use the dedicated banner image if available, otherwise fall back to the featured image.
-			$grid_image = memberlite_get_banner_image( get_the_ID(), 'large', false, array( 'class' => 'aligncenter' ) );
+			$grid_image = memberlite_get_banner_image( get_the_ID(), 'memberlite-16x9', false, array( 'class' => 'aligncenter' ) );
 			if ( empty( $grid_image ) ) {
-				$grid_image = get_the_post_thumbnail( get_the_ID(), 'large', array( 'class' => 'aligncenter' ) );
+				$grid_image = get_the_post_thumbnail( get_the_ID(), 'memberlite-16x9', array( 'class' => 'aligncenter' ) );
 			}
 			if ( ! empty( $grid_image ) ) {
 				echo $grid_image; // WPCS: xss ok.

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -28,19 +28,22 @@ $aria_attr = is_single() ? ' aria-labelledby="page-title"' : '';
 
 		$memberlite_loop_images = get_theme_mod( 'memberlite_loop_images', $memberlite_defaults['memberlite_loop_images'] );
 		if ( in_array( $memberlite_loop_images, array( 'show_thumbnail', 'show_both' ) ) && has_post_thumbnail() ) {
-			$alt = ''; // Assume purely decorative.
-			$thumbnail_id = get_post_thumbnail_id( $post->ID );
-			if ( $thumbnail_id ) {
-				$alt = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
-			}
-
-			the_post_thumbnail(
+			$thumbnail_id = get_post_thumbnail_id();
+			$alt          = $thumbnail_id ? get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ) : '';
+			$thumbnail    = get_the_post_thumbnail(
+				null,
 				'thumbnail',
 				array(
 					'class' => 'alignright',
 					'alt'   => esc_attr( $alt ),
 				)
 			);
+
+			if ( ! is_single() ) {
+				echo '<a href="' . esc_url( get_permalink() ) . '" tabindex="-1" aria-hidden="true">' . $thumbnail . '</a>';
+			} else {
+				echo $thumbnail;
+			}
 		}
 
 		if ( is_archive() || ( is_home() && get_post_type() === 'post' ) ) {

--- a/components/post/entry-header.php
+++ b/components/post/entry-header.php
@@ -18,7 +18,7 @@ if ( $content_archives != 'grid' || is_search() ) {
 
 	if ( ! empty( $memberlite_get_banner_image_src ) ) { ?>
 		<div class="entry-banner">
-			<a href="<?php echo esc_url( get_permalink() ); ?>">
+			<a href="<?php echo esc_url( get_permalink() ); ?>" tabindex="-1" aria-hidden="true">
 				<img class="banner-image" src="<?php echo esc_url( $memberlite_get_banner_image_src[0] ); ?>" alt="" aria-hidden="true" />
 			</a>
 	<?php } ?>

--- a/components/post/entry-header.php
+++ b/components/post/entry-header.php
@@ -18,7 +18,9 @@ if ( $content_archives != 'grid' || is_search() ) {
 
 	if ( ! empty( $memberlite_get_banner_image_src ) ) { ?>
 		<div class="entry-banner">
-			<img class="banner-image" src="<?php echo esc_url( $memberlite_get_banner_image_src[0] ); ?>" alt="" aria-hidden="true" />
+			<a href="<?php echo esc_url( get_permalink() ); ?>">
+				<img class="banner-image" src="<?php echo esc_url( $memberlite_get_banner_image_src[0] ); ?>" alt="" aria-hidden="true" />
+			</a>
 	<?php } ?>
 
 <?php } ?>

--- a/functions.php
+++ b/functions.php
@@ -236,6 +236,7 @@ if ( ! function_exists( 'memberlite_setup' ) ) :
 		add_image_size( 'memberlite-banner', 793, 200, true, array( 'center', 'center' ) );
 		add_image_size( 'memberlite-fullwidth', 1170, 1200, false, array( 'center', 'center' ) );
 		add_image_size( 'memberlite-masthead', 1600, 300, true, array( 'center', 'center' ) );
+		add_image_size( 'memberlite-16x9', 960, 540, true, array( 'center', 'center' ) );
 
 		// Add support for Block Styles.
 		add_theme_support( 'wp-block-styles' );

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -198,8 +198,6 @@ hr.wp-block-separator {
 
 .wp-block-button.is-style-outline .wp-block-button__link {
 	background: transparent;
-	border-color: var(--wp--preset--color--buttons);
-	color: var(--wp--preset--color--buttons);
 
 	&:hover {
 		background-color: var(--wp--preset--color--buttons);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Resolved issue where "outline" style on button block was not changing border color when a different color was selected from the color picker setting.
- Made featured images clickable on archives.
- Added a new image size for 16:9 and applied that size for our grid view banners/post thumbnails.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolved issue where "outline" style on button block was not changing border color when a different color was selected from the color picker setting. Made featured images clickable on archives. Added a new image size for 16:9 and applied that size for our grid view banners/post thumbnails.
