### PR TITLE
Fix so footer variations properly pull on single post for CPTs.

### DIFF
--- a/inc/variations.php
+++ b/inc/variations.php
@@ -248,7 +248,7 @@ function memberlite_get_current_footer_post_name(): string {
 		if ( '' !== $override && isset( $footer_variations[ $override ] ) ) {
 			$post_name = $override;
 		} else {
-			if ( is_singular( 'post' ) ) {
+			if ( is_single() ) {
 				$post_name = get_theme_mod( 'memberlite_post_footer_slug', 'memberlite-global-footer' );
 			} elseif ( is_page() ) {
 				$post_name = get_theme_mod( 'memberlite_page_footer_slug', 'memberlite-global-footer' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves the bug where CPTs archives and single posts were not pulling the correct global footer variation from customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolved the bug where CPTs archives and single posts were not pulling the correct global footer variation from customizer.
