### PR TITLE
Fallback to default sidebar behavior when forum sidebar is not configured

### DIFF
--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -374,9 +374,12 @@ function memberlite_get_widget_areas() {
 		}
 	}
 
-	// Special case for bbPress search results page.
+	// For bbPress pages (except single topics), use a forum-specific sidebar if one is configured.
 	if ( empty( $memberlite_custom_sidebar ) && function_exists( 'is_bbpress' ) && is_bbpress() && ! bbp_is_single_topic() ) {
-		$widget_areas = array( memberlite_get_default_sidebar_by_post_type( 'forum' ) );
+		$forum_sidebar = memberlite_get_default_sidebar_by_post_type( 'forum' );
+		if ( ! empty( $forum_sidebar ) && 'memberlite_sidebar_default' !== $forum_sidebar ) {
+			$widget_areas = array( $forum_sidebar );
+		}
 	}
 
 	// If no custom sidebar for this specific post and we're on a blog page, check if the blog page has one to inherit.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

## Bug: bbPress pages show empty sidebar column when no forum CPT sidebar is configured

### Problem

On bbPress forum pages, the sidebar column would render visibly in the layout (respecting the Customizer layout settings) but contain no widgets.

The cause was in `memberlite_get_widget_areas()` in `inc/sidebars.php`. For bbPress pages, the function unconditionally replaced the default widget areas with the result of `memberlite_get_default_sidebar_by_post_type( 'forum' )`:

```php
$widget_areas = array( memberlite_get_default_sidebar_by_post_type( 'forum' ) );
```

When no forum-specific CPT sidebar had been configured in **Memberlite → Custom Sidebars**, that function returns `false`, resulting in `$widget_areas = array( false )`. Calling `dynamic_sidebar( false )` renders nothing, leaving the sidebar column empty even though the layout expected content there.

### Fix

Guard the override so it only applies when a valid forum CPT sidebar is actually configured. If none is set (or the value is the `'memberlite_sidebar_default'` sentinel), `$widget_areas` is left unchanged, falling back to `sidebar-2` (Posts & Archives) as it would for any other non-page, non-blog context.

```php
$forum_sidebar = memberlite_get_default_sidebar_by_post_type( 'forum' );
if ( ! empty( $forum_sidebar ) && 'memberlite_sidebar_default' !== $forum_sidebar ) {
    $widget_areas = array( $forum_sidebar );
}
```

### Behavior After Fix

| Forum CPT sidebar setting | Before | After |
|---|---|---|
| Not configured | Empty sidebar column | Falls back to `sidebar-2` |
| Configured to a specific sidebar | Used that sidebar ✓ | Used that sidebar ✓ |
| Set to `memberlite_sidebar_default` | Empty sidebar column | Falls back to `sidebar-2` |

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
