### PR TITLE
Fix: Export theme settings now include blog name and description options

### DIFF
--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -135,6 +135,8 @@ function memberlite_export_theme_settings() {
 		$option_keys = apply_filters(
 			'memberlite_export_option_keys',
 			array(
+				'blogname',
+				'blogdescription',
 				'site_icon',
 				'memberlite_cpt_sidebars',
 				'memberlite_custom_sidebars',

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -137,7 +137,6 @@ function memberlite_export_theme_settings() {
 			array(
 				'blogname',
 				'blogdescription',
-				'site_icon',
 				'memberlite_cpt_sidebars',
 				'memberlite_custom_sidebars',
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Fixed:** Site Title (blogname) and Site Tagline (blogdescription) were missing because WordPress stores them as options, not theme mods — added both to `$option_keys` so they're now exported via `get_option()`.

**The site logo and site icon** won't export/import by just passing the options from one environment to another due to attachment IDs/paths being different. This would have to be a separate feature if it's something we want to pursue. For now, I'm removing site icon from the export functionality because it doesn't work anyway.

ℹ️ I also noticed if I used the block versions, for example, the site logo and added a logo when the setting in Customizer was empty, it properly updates the Customizer setting for it. As far as I understand, the blocks for Site Title, Site Tagline and Site Logo either use the same option name or sync so that regardless of whether it's set from Customizer or the block, it'll be included in our export.

### How to test the changes in this Pull Request:

1. You need two Memberlite environments.
2. In environment A, make sure you have a logo, title, tagline and icon set under **Customize > Site Identity**.
3. Go to **Memberlite > Tools > Export Theme Settings** with the "Theme Settings" checkbox checked. Click the "Download Export File" button.
4. On environment B, first note that any existing theme mods will be written once you import. If that's okay, go to **Memberlite > Tools > Import Theme Settings**.
5. Upload the JSON file that was generated when you exported from environment A. Click the "Import Theme Settings" checkbox.
6. Check your customizer settings on environment B to confirm that the `theme_mods` were properly imported.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Export theme settings now include blog name and description options.
