### PR TITLE
Add new settings under "Tools" to clone settings from parent theme when child is active

### DIFF
--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -268,7 +268,7 @@ add_action( 'admin_post_memberlite_export_theme_settings', 'memberlite_export_th
  * Apply an array of theme mods to the active theme.
  * Clears existing mods, skips deprecated keys, and sanitizes color values.
  *
- * @since 7.2
+ * @since TBD
  * @param array $mods Associative array of mod key => value.
  */
 function memberlite_apply_theme_mods( array $mods ) {
@@ -520,7 +520,7 @@ add_action( 'admin_post_memberlite_import_theme_settings', 'memberlite_import_th
 /**
  * Handle cloning theme mods from the parent theme to the active child theme.
  *
- * @since 7.2
+ * @since TBD
  */
 function memberlite_clone_parent_theme_settings() {
 	if ( ! current_user_can( 'edit_theme_options' ) ) {

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -56,6 +56,13 @@ function memberlite_tools() {
 					$message = __( 'Memberlite theme settings were imported successfully.', 'memberlite' );
 					$class   = 'notice-success';
 					break;
+				case 'clone_ok':
+					$message = __( 'Parent theme settings were copied to your child theme successfully.', 'memberlite' );
+					$class   = 'notice-success';
+					break;
+				case 'no_parent_mods':
+					$message = __( 'No settings were found on the parent theme to copy.', 'memberlite' );
+					break;
 			}
 		}
 
@@ -258,6 +265,51 @@ function memberlite_export_theme_settings() {
 add_action( 'admin_post_memberlite_export_theme_settings', 'memberlite_export_theme_settings' );
 
 /**
+ * Apply an array of theme mods to the active theme.
+ * Clears existing mods, skips deprecated keys, and sanitizes color values.
+ *
+ * @since 7.2
+ * @param array $mods Associative array of mod key => value.
+ */
+function memberlite_apply_theme_mods( array $mods ) {
+	remove_theme_mods();
+
+	$color_keys      = memberlite_get_color_setting_keys();
+	$deprecated_mods = array( 'memberlite_darkcss' );
+
+	foreach ( $mods as $key => $value ) {
+		if ( in_array( $key, $deprecated_mods, true ) ) {
+			continue;
+		}
+
+		if ( in_array( $key, $color_keys, true ) && is_string( $value ) ) {
+			$value = sanitize_hex_color_no_hash( $value );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$value = strtolower( $value );
+		}
+
+		set_theme_mod( $key, $value );
+	}
+
+	$imported_scheme = isset( $mods['memberlite_color_scheme'] ) ? $mods['memberlite_color_scheme'] : '';
+	$final_scheme    = 'custom';
+
+	if ( is_string( $imported_scheme ) && ! empty( $imported_scheme ) && 'custom' !== $imported_scheme ) {
+		$modern_schemes = memberlite_get_color_schemes();
+
+		if ( isset( $modern_schemes[ $imported_scheme ] ) ) {
+			$final_scheme = $imported_scheme;
+		}
+	}
+
+	set_theme_mod( 'memberlite_color_scheme', $final_scheme );
+}
+
+/**
  * Handle Memberlite theme settings import.
  *
  * @since 6.1
@@ -304,54 +356,7 @@ function memberlite_import_theme_settings() {
 
 	// Overwrite current theme mods if present.
 	if ( isset( $data['mods'] ) && is_array( $data['mods'] ) ) {
-		// Clear existing mods so we don't leave stale ones behind.
-		remove_theme_mods();
-
-		// Get all color setting keys.
-		$color_keys = memberlite_get_color_setting_keys();
-
-		// Deprecated mods to skip on import.
-		$deprecated_mods = array( 'memberlite_darkcss' );
-
-		foreach ( $data['mods'] as $key => $value ) {
-			// Skip deprecated settings.
-			if ( in_array( $key, $deprecated_mods, true ) ) {
-				continue;
-			}
-
-			// Sanitize color values to remove # prefix
-			if ( in_array( $key, $color_keys, true ) && is_string( $value ) ) {
-				$value = sanitize_hex_color_no_hash( $value );
-
-				// Skip if sanitization failed (returns null for invalid colors)
-				if ( $value === null ) {
-					continue;
-				}
-
-				// Lowercase for consistency
-				$value = strtolower( $value );
-			}
-
-			set_theme_mod( $key, $value );
-		}
-
-		// Now detect if the imported color scheme is legacy or modern
-		$imported_scheme = isset( $data['mods']['memberlite_color_scheme'] ) ? $data['mods']['memberlite_color_scheme'] : '';
-		$final_scheme = 'custom'; // Default to custom if we can't determine the color scheme
-
-		// Type safety: ensure it's a string before using as array key
-		if ( is_string( $imported_scheme ) && ! empty( $imported_scheme ) && $imported_scheme !== 'custom' ) {
-			// Check if it's a modern scheme
-			$modern_schemes = memberlite_get_color_schemes();
-
-			if ( isset( $modern_schemes[ $imported_scheme ] ) ) {
-				// It's a valid modern scheme, keep it as-is
-				$final_scheme = $imported_scheme;
-			}
-		}
-
-		// Anything legacy or a malformed color scheme will default to "custom"
-		set_theme_mod( 'memberlite_color_scheme', $final_scheme );
+		memberlite_apply_theme_mods( $data['mods'] );
 	}
 
 	// Restore extra options (site_icon, sidebars, etc.), if present.
@@ -511,6 +516,43 @@ function memberlite_import_theme_settings() {
 	memberlite_import_settings_redirect( 'import_ok' );
 }
 add_action( 'admin_post_memberlite_import_theme_settings', 'memberlite_import_theme_settings' );
+
+/**
+ * Handle cloning theme mods from the parent theme to the active child theme.
+ *
+ * @since 7.2
+ */
+function memberlite_clone_parent_theme_settings() {
+	if ( ! current_user_can( 'edit_theme_options' ) ) {
+		wp_die( esc_html__( 'You are not allowed to import theme settings.', 'memberlite' ) );
+	}
+
+	if ( empty( $_POST['memberlite_import_theme_settings_nonce'] ) ) {
+		wp_die( esc_html__( 'Invalid import request.', 'memberlite' ) );
+	}
+
+	check_admin_referer( 'memberlite_import_theme_settings', 'memberlite_import_theme_settings_nonce' );
+
+	if ( ! is_child_theme() ) {
+		wp_die( esc_html__( 'This operation requires a child theme to be active.', 'memberlite' ) );
+	}
+
+	$parent_mods = get_option( 'theme_mods_' . get_template() );
+
+	if ( ! is_array( $parent_mods ) || empty( $parent_mods ) ) {
+		memberlite_import_settings_redirect( 'no_parent_mods' );
+	}
+
+	memberlite_apply_theme_mods( $parent_mods );
+
+	$parent_css = wp_get_custom_css( get_template() );
+	if ( $parent_css && function_exists( 'wp_update_custom_css_post' ) ) {
+		wp_update_custom_css_post( $parent_css );
+	}
+
+	memberlite_import_settings_redirect( 'clone_ok' );
+}
+add_action( 'admin_post_memberlite_clone_parent_theme_settings', 'memberlite_clone_parent_theme_settings' );
 
 /**
  * Helper: redirect back to the Tools page with a status flag.

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -277,8 +277,15 @@ function memberlite_apply_theme_mods( array $mods ) {
 	$color_keys      = memberlite_get_color_setting_keys();
 	$deprecated_mods = array( 'memberlite_darkcss' );
 
+	// Internal WordPress keys that must never be copied between themes.
+	$internal_keys = array( 'custom_css_post_id' );
+
 	foreach ( $mods as $key => $value ) {
 		if ( in_array( $key, $deprecated_mods, true ) ) {
+			continue;
+		}
+
+		if ( in_array( $key, $internal_keys, true ) || strpos( $key, '_transient_' ) === 0 ) {
 			continue;
 		}
 

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -57,7 +57,7 @@ function memberlite_tools() {
 					$class   = 'notice-success';
 					break;
 				case 'clone_ok':
-					$message = __( 'Parent theme settings were copied to your child theme successfully.', 'memberlite' );
+					$message = __( 'Parent theme settings were cloned and imported to your child theme successfully.', 'memberlite' );
 					$class   = 'notice-success';
 					break;
 				case 'no_parent_mods':

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -272,47 +272,59 @@ add_action( 'admin_post_memberlite_export_theme_settings', 'memberlite_export_th
  * @param array $mods Associative array of mod key => value.
  */
 function memberlite_apply_theme_mods( array $mods ) {
+	// Clear existing mods so we don't leave stale ones behind.
 	remove_theme_mods();
 
+	// Get all color setting keys.
 	$color_keys      = memberlite_get_color_setting_keys();
+
+	// Deprecated mods to skip on import.
 	$deprecated_mods = array( 'memberlite_darkcss' );
 
 	// Internal WordPress keys that must never be copied between themes.
 	$internal_keys = array( 'custom_css_post_id' );
 
 	foreach ( $mods as $key => $value ) {
+		// Skip deprecated settings.
 		if ( in_array( $key, $deprecated_mods, true ) ) {
 			continue;
 		}
 
+		// Skip internal keys and transient keys
 		if ( in_array( $key, $internal_keys, true ) || strpos( $key, '_transient_' ) === 0 ) {
 			continue;
 		}
 
+		// Sanitize color values to remove # prefix
 		if ( in_array( $key, $color_keys, true ) && is_string( $value ) ) {
 			$value = sanitize_hex_color_no_hash( $value );
 
+			// Skip if sanitization failed (returns null for invalid colors)
 			if ( null === $value ) {
 				continue;
 			}
 
+			// Lowercase for consistency
 			$value = strtolower( $value );
 		}
 
 		set_theme_mod( $key, $value );
 	}
 
+	// Now detect if the imported color scheme is legacy or modern
 	$imported_scheme = isset( $mods['memberlite_color_scheme'] ) ? $mods['memberlite_color_scheme'] : '';
 	$final_scheme    = 'custom';
 
 	if ( is_string( $imported_scheme ) && ! empty( $imported_scheme ) && 'custom' !== $imported_scheme ) {
+		// Check if it's a modern scheme
 		$modern_schemes = memberlite_get_color_schemes();
 
 		if ( isset( $modern_schemes[ $imported_scheme ] ) ) {
-			$final_scheme = $imported_scheme;
+			$final_scheme = $imported_scheme; // Default to custom if we can't determine the color scheme
 		}
 	}
 
+	// Anything legacy or a malformed color scheme will default to "custom"
 	set_theme_mod( 'memberlite_color_scheme', $final_scheme );
 }
 

--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -562,7 +562,16 @@ function memberlite_clone_parent_theme_settings() {
 		memberlite_import_settings_redirect( 'no_parent_mods' );
 	}
 
+	// Preserve the child theme's menu location assignments — cloning design settings
+	// should not affect which menus are assigned to which locations in the child.
+	$child_nav_menu_locations = get_theme_mod( 'nav_menu_locations' );
+
 	memberlite_apply_theme_mods( $parent_mods );
+
+	// Restore child menu locations after apply (remove_theme_mods wipes them).
+	if ( ! empty( $child_nav_menu_locations ) ) {
+		set_theme_mod( 'nav_menu_locations', $child_nav_menu_locations );
+	}
 
 	$parent_css = wp_get_custom_css( get_template() );
 	if ( $parent_css && function_exists( 'wp_update_custom_css_post' ) ) {

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $memberlite_is_child      = is_child_theme();
-$memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() )->get( 'Name' ) : '';
 ?>
 <div id="memberlite_tools_import_settings" class="memberlite_section" data-visibility="shown" data-activated="true">
 	<div class="memberlite_section_toggle">
@@ -20,14 +19,8 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 		</button>
 	</div>
 	<div class="memberlite_section_inside">
-		<p><?php esc_html_e( 'Use the tool below to import Memberlite theme settings.', 'memberlite' ); ?></p>
-		<p><span class="dashicons dashicons-warning" aria-hidden="true"></span><strong><?php esc_html_e( 'This will overwrite your current theme settings.', 'memberlite' ); ?></strong></p>
-
-		<?php if ( $memberlite_is_child ) { ?>
-			<p><?php esc_html_e( 'Both methods import Customizer settings (logo, colors, typography, backgrounds, etc.) and Additional CSS to the active theme.', 'memberlite' ); ?></p>
-		<?php } else { ?>
-			<?php esc_html_e( 'The import will include Customizer settings (logo, colors, typography, backgrounds, Additional CSS etc.), related Memberlite options (such as custom sidebars), and navigation menus if present in the file.', 'memberlite' ); ?>
-		<?php } ?>
+		<p><?php esc_html_e( 'Use the tool below to import Memberlite theme settings. These settings include Customizer settings (logo, colors, typography, backgrounds, etc.) and Additional CSS.', 'memberlite' ); ?></p>
+		<p><span class="dashicons dashicons-warning" aria-hidden="true"></span><strong><?php esc_html_e( 'Importing settings will replace your current theme settings.', 'memberlite' ); ?></strong></p>
 
 		<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<table class="form-table">
@@ -39,56 +32,49 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 							<fieldset>
 								<label>
 									<input type="radio" name="memberlite_import_source" value="file" checked />
-									<?php esc_html_e( 'Import from file', 'memberlite' ); ?>
+									<?php esc_html_e( 'Import from file.', 'memberlite' ); ?>
 								</label>
 								<p class="description">
-									<?php esc_html_e( 'Imports Customizer settings and Additional CSS, Memberlite-specific options (such as custom sidebars and site icon) and navigation menus if they are included in the file.', 'memberlite' ); ?>
+									<?php esc_html_e( 'Imports Customizer settings, theme-specific options (site icon, custom sidebars), and menus (if included).', 'memberlite' ); ?>
 								</p>
 								<br />
 								<label>
 									<input type="radio" name="memberlite_import_source" value="clone" />
-									<?php
-									printf(
-										/* translators: %s: parent theme name */
-										esc_html__( 'Clone settings from parent theme (%s)', 'memberlite' ),
-										esc_html( $memberlite_parent_name )
-									);
-									?>
+									<?php esc_html_e( 'Import settings from Memberlite parent theme.', 'memberlite' ); ?>
 								</label>
 								<p class="description">
-									<?php
-									printf(
-									/* translators: %s: parent theme name */
-										esc_html__( 'Copies Customizer settings and Additional CSS directly from the %s parent theme. Navigation menu items are not modified — existing menus remain intact, and their location assignments are carried over from the parent theme.', 'memberlite' ),
-										esc_html( $memberlite_parent_name )
-									);
-									?>
+									<?php esc_html_e( 'Copies settings from the active parent theme. Existing menus and theme-specific options are preserved.', 'memberlite' ); ?>
 								</p>
 							</fieldset>
 						</td>
 					</tr>
 					<?php } ?>
-					<tr id="memberlite_import_file_row">
+					<tr id="memberlite-import-file-row">
 						<th scope="row">
-							<label for="memberlite_import_file"><?php esc_html_e( 'Import File', 'memberlite' ); ?></label>
+							<label for="memberlite-import-file"><?php esc_html_e( 'Import File', 'memberlite' ); ?></label>
 						</th>
 						<td>
-							<input type="file" name="memberlite_import_file" id="memberlite_import_file" accept=".json" />
+							<input type="file" name="memberlite_import_file" id="memberlite-import-file" accept=".json" />
 							<p class="description">
 								<?php esc_html_e( 'Select a Memberlite theme settings file (.json) to import.', 'memberlite' ); ?>
 							</p>
+							<?php if (! $memberlite_is_child) { ?>
+								<p class="description">
+									<?php esc_html_e( 'Imports Customizer settings, theme-specific options (site icon, custom sidebars), and menus (if included).', 'memberlite' ); ?>
+								</p>
+							<?php } ?>
 						</td>
 					</tr>
-					<tr id="memberlite_import_menus_row">
+					<tr id="memberlite-import-menus-row">
 						<th scope="row"><?php esc_html_e( 'Menu Import Options', 'memberlite' ); ?></th>
 						<td>
 							<fieldset>
 								<label>
 									<input type="checkbox" name="memberlite_replace_existing_menus" value="1" />
-									<?php esc_html_e( 'Replace existing menus with imported versions', 'memberlite' ); ?>
+									<?php esc_html_e( 'Replace menus with imported menus', 'memberlite' ); ?>
 								</label>
 								<p class="description">
-									<?php esc_html_e( 'If checked, any existing menu with the same name will be replaced. If unchecked, a new duplicate menu will be created instead.', 'memberlite' ); ?>
+									<?php esc_html_e( 'If unchecked, imported menus will be added as new menus instead of replacing existing ones.', 'memberlite' ); ?>
 								</p>
 							</fieldset>
 						</td>
@@ -97,29 +83,25 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 			</table>
 			<p class="submit">
 				<?php wp_nonce_field( 'memberlite_import_theme_settings', 'memberlite_import_theme_settings_nonce' ); ?>
-				<input type="hidden" name="action" id="memberlite_import_action" value="memberlite_import_theme_settings" />
-				<button type="submit" id="memberlite_import_submit" class="button button-primary"><?php esc_html_e( 'Import Theme Settings', 'memberlite' ); ?></button>
+				<input type="hidden" name="action" id="memberlite-import-action" value="memberlite_import_theme_settings" />
+				<button type="submit" class="button button-primary"><?php esc_html_e( 'Import Theme Settings', 'memberlite' ); ?></button>
 			</p>
 		</form>
 		<?php if ( $memberlite_is_child ) { ?>
 		<script>
 		( function() {
-			var radios      = document.querySelectorAll( 'input[name="memberlite_import_source"]' );
-			var fileRow     = document.getElementById( 'memberlite_import_file_row' );
-			var menusRow    = document.getElementById( 'memberlite_import_menus_row' );
-			var actionField = document.getElementById( 'memberlite_import_action' );
-			var submitBtn   = document.getElementById( 'memberlite_import_submit' );
-			var fileInput   = document.getElementById( 'memberlite_import_file' );
-			var labelImport = <?php echo wp_json_encode( __( 'Import Theme Settings', 'memberlite' ) ); ?>;
-			var labelClone  = <?php echo wp_json_encode( __( 'Clone Settings from Parent Theme', 'memberlite' ) ); ?>;
+			const radios      = document.querySelectorAll( 'input[name="memberlite_import_source"]' ),
+				fileRow     = document.getElementById( 'memberlite-import-file-row' ),
+				menusRow    = document.getElementById( 'memberlite-import-menus-row' ),
+				actionField = document.getElementById( 'memberlite-import-action' ),
+				fileInput   = document.getElementById( 'memberlite-import-file' );
 
 			function updateMode( mode ) {
-				var isClone = ( mode === 'clone' );
+				let isClone = ( mode === 'clone' );
 				fileRow.style.display     = isClone ? 'none' : '';
 				menusRow.style.display    = isClone ? 'none' : '';
 				fileInput.disabled        = isClone;
 				actionField.value         = isClone ? 'memberlite_clone_parent_theme_settings' : 'memberlite_import_theme_settings';
-				submitBtn.textContent     = isClone ? labelClone : labelImport;
 			}
 
 			Array.prototype.forEach.call( radios, function( radio ) {

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -107,7 +107,6 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 			var radios      = document.querySelectorAll( 'input[name="memberlite_import_source"]' );
 			var fileRow     = document.getElementById( 'memberlite_import_file_row' );
 			var menusRow    = document.getElementById( 'memberlite_import_menus_row' );
-			var cloneRow    = document.getElementById( 'memberlite_clone_description_row' );
 			var actionField = document.getElementById( 'memberlite_import_action' );
 			var submitBtn   = document.getElementById( 'memberlite_import_submit' );
 			var fileInput   = document.getElementById( 'memberlite_import_file' );
@@ -118,7 +117,6 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 				var isClone = ( mode === 'clone' );
 				fileRow.style.display     = isClone ? 'none' : '';
 				menusRow.style.display    = isClone ? 'none' : '';
-				cloneRow.style.display    = isClone ? '' : 'none';
 				fileInput.disabled        = isClone;
 				actionField.value         = isClone ? 'memberlite_clone_parent_theme_settings' : 'memberlite_import_theme_settings';
 				submitBtn.textContent     = isClone ? labelClone : labelImport;

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -22,6 +22,13 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 	<div class="memberlite_section_inside">
 		<p><?php esc_html_e( 'Use the tool below to import Memberlite theme settings.', 'memberlite' ); ?></p>
 		<p><span class="dashicons dashicons-warning" aria-hidden="true"></span><strong><?php esc_html_e( 'This will overwrite your current theme settings.', 'memberlite' ); ?></strong></p>
+
+		<?php if ( $memberlite_is_child ) { ?>
+			<p><?php esc_html_e( 'Both methods import Customizer settings (logo, colors, typography, backgrounds, etc.) and Additional CSS to the active theme.', 'memberlite' ); ?></p>
+		<?php } else { ?>
+			<?php esc_html_e( 'The import will include Customizer settings (logo, colors, typography, backgrounds, Additional CSS etc.), related Memberlite options (such as custom sidebars), and navigation menus if present in the file.', 'memberlite' ); ?>
+		<?php } ?>
+
 		<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<table class="form-table">
 				<tbody>
@@ -34,7 +41,9 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 									<input type="radio" name="memberlite_import_source" value="file" checked />
 									<?php esc_html_e( 'Import from file', 'memberlite' ); ?>
 								</label>
-								<p class="description"><?php esc_html_e( 'The import will include Customizer settings (logo, colors, typography, backgrounds, Additional CSS etc.), related Memberlite options (such as custom sidebars), and navigation menus if present in the file.', 'memberlite' ); ?></p>
+								<p class="description">
+									<?php esc_html_e( 'Imports Customizer settings and Additional CSS, Memberlite-specific options (such as custom sidebars and site icon) and navigation menus if they are included in the file.', 'memberlite' ); ?>
+								</p>
 								<br />
 								<label>
 									<input type="radio" name="memberlite_import_source" value="clone" />
@@ -46,6 +55,15 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 									);
 									?>
 								</label>
+								<p class="description">
+									<?php
+									printf(
+									/* translators: %s: parent theme name */
+										esc_html__( 'Copies Customizer settings and Additional CSS directly from the %s parent theme. Navigation menu items are not modified — existing menus remain intact, and their location assignments are carried over from the parent theme.', 'memberlite' ),
+										esc_html( $memberlite_parent_name )
+									);
+									?>
+								</p>
 							</fieldset>
 						</td>
 					</tr>
@@ -75,25 +93,6 @@ $memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() 
 							</fieldset>
 						</td>
 					</tr>
-					<?php if ( $memberlite_is_child ) { ?>
-					<tr id="memberlite_clone_description_row" style="display:none;">
-						<th scope="row"><?php esc_html_e( 'Clone Settings', 'memberlite' ); ?></th>
-						<td>
-							<p class="description">
-								<span class="dashicons dashicons-warning" aria-hidden="true"></span>
-								<strong>
-								<?php
-								printf(
-									/* translators: %s: parent theme name */
-									esc_html__( 'This will copy all Customizer settings from the %s parent theme to your child theme, overwriting any existing child theme settings.', 'memberlite' ),
-									esc_html( $memberlite_parent_name )
-								);
-								?>
-								</strong>
-							</p>
-						</td>
-					</tr>
-					<?php } ?>
 				</tbody>
 			</table>
 			<p class="submit">

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$memberlite_is_child      = is_child_theme();
+$memberlite_is_child = is_child_theme();
 ?>
 <div id="memberlite_tools_import_settings" class="memberlite_section" data-visibility="shown" data-activated="true">
 	<div class="memberlite_section_toggle">
@@ -58,7 +58,7 @@ $memberlite_is_child      = is_child_theme();
 							<p class="description">
 								<?php esc_html_e( 'Select a Memberlite theme settings file (.json) to import.', 'memberlite' ); ?>
 							</p>
-							<?php if (! $memberlite_is_child) { ?>
+							<?php if ( ! $memberlite_is_child ) { ?>
 								<p class="description">
 									<?php esc_html_e( 'Imports Customizer settings, theme-specific options (site icon, custom sidebars), and menus (if included).', 'memberlite' ); ?>
 								</p>
@@ -91,7 +91,7 @@ $memberlite_is_child      = is_child_theme();
 		<p><?php printf(
 				/* translators: %s: link to the WordPress Tools > Import admin page */
 				esc_html__( 'To import WordPress content such as posts, pages, headers, footers, and media, use the built-in WordPress %s page.', 'memberlite' ),
-				'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools &gt; Import', 'memberlite' ) . '</a>'
+				'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools > Import', 'memberlite' ) . '</a>'
 			); ?></p>
 	</div>
 </div>

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -87,31 +87,6 @@ $memberlite_is_child      = is_child_theme();
 				<button type="submit" class="button button-primary"><?php esc_html_e( 'Import Theme Settings', 'memberlite' ); ?></button>
 			</p>
 		</form>
-		<?php if ( $memberlite_is_child ) { ?>
-		<script>
-		( function() {
-			const radios      = document.querySelectorAll( 'input[name="memberlite_import_source"]' ),
-				fileRow     = document.getElementById( 'memberlite-import-file-row' ),
-				menusRow    = document.getElementById( 'memberlite-import-menus-row' ),
-				actionField = document.getElementById( 'memberlite-import-action' ),
-				fileInput   = document.getElementById( 'memberlite-import-file' );
-
-			function updateMode( mode ) {
-				let isClone = ( mode === 'clone' );
-				fileRow.style.display     = isClone ? 'none' : '';
-				menusRow.style.display    = isClone ? 'none' : '';
-				fileInput.disabled        = isClone;
-				actionField.value         = isClone ? 'memberlite_clone_parent_theme_settings' : 'memberlite_import_theme_settings';
-			}
-
-			Array.prototype.forEach.call( radios, function( radio ) {
-				radio.addEventListener( 'change', function() {
-					updateMode( this.value );
-				} );
-			} );
-		}() );
-		</script>
-		<?php } ?>
 		<hr />
 		<p><?php printf(
 				/* translators: %s: link to the WordPress Tools > Import admin page */

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -8,6 +8,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+$memberlite_is_child      = is_child_theme();
+$memberlite_parent_name   = $memberlite_is_child ? wp_get_theme( get_template() )->get( 'Name' ) : '';
 ?>
 <div id="memberlite_tools_import_settings" class="memberlite_section" data-visibility="shown" data-activated="true">
 	<div class="memberlite_section_toggle">
@@ -17,44 +20,119 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</button>
 	</div>
 	<div class="memberlite_section_inside">
-		<p><?php esc_html_e( 'Use the tool below to import Memberlite theme settings from a previously exported settings file.', 'memberlite' ); ?> <strong><?php esc_html_e( 'This will overwrite your current Memberlite theme settings.', 'memberlite' ); ?></strong></p>
-		<p><?php esc_html_e( 'The import will apply Customizer settings (logo, colors, typography, backgrounds, etc.), related Memberlite options (such as custom sidebars), Additional CSS, and navigation menus if present in the file.', 'memberlite' ); ?></p>
+		<p><?php esc_html_e( 'Use the tool below to import Memberlite theme settings.', 'memberlite' ); ?></p>
+		<p><span class="dashicons dashicons-warning" aria-hidden="true"></span><strong><?php esc_html_e( 'This will overwrite your current theme settings.', 'memberlite' ); ?></strong></p>
 		<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<table class="form-table">
-					<tbody>
-						<tr>
-							<th scope="row">
-								<label for="memberlite_import_file"><?php esc_html_e( 'Import File', 'memberlite' ); ?></label>
-							</th>
-							<td>
-								<input type="file" name="memberlite_import_file" id="memberlite_import_file" accept=".json" />
+				<tbody>
+					<?php if ( $memberlite_is_child ) { ?>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Import Source', 'memberlite' ); ?></th>
+						<td>
+							<fieldset>
+								<label>
+									<input type="radio" name="memberlite_import_source" value="file" checked />
+									<?php esc_html_e( 'Import from file', 'memberlite' ); ?>
+								</label>
+								<p class="description"><?php esc_html_e( 'The import will include Customizer settings (logo, colors, typography, backgrounds, Additional CSS etc.), related Memberlite options (such as custom sidebars), and navigation menus if present in the file.', 'memberlite' ); ?></p>
+								<br />
+								<label>
+									<input type="radio" name="memberlite_import_source" value="clone" />
+									<?php
+									printf(
+										/* translators: %s: parent theme name */
+										esc_html__( 'Clone settings from parent theme (%s)', 'memberlite' ),
+										esc_html( $memberlite_parent_name )
+									);
+									?>
+								</label>
+							</fieldset>
+						</td>
+					</tr>
+					<?php } ?>
+					<tr id="memberlite_import_file_row">
+						<th scope="row">
+							<label for="memberlite_import_file"><?php esc_html_e( 'Import File', 'memberlite' ); ?></label>
+						</th>
+						<td>
+							<input type="file" name="memberlite_import_file" id="memberlite_import_file" accept=".json" />
+							<p class="description">
+								<?php esc_html_e( 'Select a Memberlite theme settings file (.json) to import.', 'memberlite' ); ?>
+							</p>
+						</td>
+					</tr>
+					<tr id="memberlite_import_menus_row">
+						<th scope="row"><?php esc_html_e( 'Menu Import Options', 'memberlite' ); ?></th>
+						<td>
+							<fieldset>
+								<label>
+									<input type="checkbox" name="memberlite_replace_existing_menus" value="1" />
+									<?php esc_html_e( 'Replace existing menus with imported versions', 'memberlite' ); ?>
+								</label>
 								<p class="description">
-									<?php esc_html_e( 'Select a Memberlite theme settings file (.json) to import.', 'memberlite' ); ?>
+									<?php esc_html_e( 'If checked, any existing menu with the same name will be replaced. If unchecked, a new duplicate menu will be created instead.', 'memberlite' ); ?>
 								</p>
-							</td>
-						</tr>
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Menu Import Options', 'memberlite' ); ?></th>
-							<td>
-								<fieldset>
-									<label>
-										<input type="checkbox" name="memberlite_replace_existing_menus" value="1" />
-										<?php esc_html_e( 'Replace existing menus with imported versions', 'memberlite' ); ?>
-									</label>
-									<p class="description">
-										<?php esc_html_e( 'If checked, any existing menu with the same name will be replaced. If unchecked, a new duplicate menu will be created instead.', 'memberlite' ); ?>
-									</p>
-								</fieldset>
-							</td>
-						</tr>
-					</tbody>
+							</fieldset>
+						</td>
+					</tr>
+					<?php if ( $memberlite_is_child ) { ?>
+					<tr id="memberlite_clone_description_row" style="display:none;">
+						<th scope="row"><?php esc_html_e( 'Clone Settings', 'memberlite' ); ?></th>
+						<td>
+							<p class="description">
+								<span class="dashicons dashicons-warning" aria-hidden="true"></span>
+								<strong>
+								<?php
+								printf(
+									/* translators: %s: parent theme name */
+									esc_html__( 'This will copy all Customizer settings from the %s parent theme to your child theme, overwriting any existing child theme settings.', 'memberlite' ),
+									esc_html( $memberlite_parent_name )
+								);
+								?>
+								</strong>
+							</p>
+						</td>
+					</tr>
+					<?php } ?>
+				</tbody>
 			</table>
 			<p class="submit">
 				<?php wp_nonce_field( 'memberlite_import_theme_settings', 'memberlite_import_theme_settings_nonce' ); ?>
-				<input type="hidden" name="action" value="memberlite_import_theme_settings" />
-				<button type="submit" class="button button-primary"><?php esc_html_e( 'Import Theme Settings', 'memberlite' ); ?></button>
+				<input type="hidden" name="action" id="memberlite_import_action" value="memberlite_import_theme_settings" />
+				<button type="submit" id="memberlite_import_submit" class="button button-primary"><?php esc_html_e( 'Import Theme Settings', 'memberlite' ); ?></button>
 			</p>
 		</form>
+		<?php if ( $memberlite_is_child ) { ?>
+		<script>
+		( function() {
+			var radios      = document.querySelectorAll( 'input[name="memberlite_import_source"]' );
+			var fileRow     = document.getElementById( 'memberlite_import_file_row' );
+			var menusRow    = document.getElementById( 'memberlite_import_menus_row' );
+			var cloneRow    = document.getElementById( 'memberlite_clone_description_row' );
+			var actionField = document.getElementById( 'memberlite_import_action' );
+			var submitBtn   = document.getElementById( 'memberlite_import_submit' );
+			var fileInput   = document.getElementById( 'memberlite_import_file' );
+			var labelImport = <?php echo wp_json_encode( __( 'Import Theme Settings', 'memberlite' ) ); ?>;
+			var labelClone  = <?php echo wp_json_encode( __( 'Clone Settings from Parent Theme', 'memberlite' ) ); ?>;
+
+			function updateMode( mode ) {
+				var isClone = ( mode === 'clone' );
+				fileRow.style.display     = isClone ? 'none' : '';
+				menusRow.style.display    = isClone ? 'none' : '';
+				cloneRow.style.display    = isClone ? '' : 'none';
+				fileInput.disabled        = isClone;
+				actionField.value         = isClone ? 'memberlite_clone_parent_theme_settings' : 'memberlite_import_theme_settings';
+				submitBtn.textContent     = isClone ? labelClone : labelImport;
+			}
+
+			Array.prototype.forEach.call( radios, function( radio ) {
+				radio.addEventListener( 'change', function() {
+					updateMode( this.value );
+				} );
+			} );
+		}() );
+		</script>
+		<?php } ?>
 		<hr />
 		<p><?php esc_html_e( 'To import WordPress content such as posts, pages, and media, use the built-in WordPress tools located at Tools > Import in the WordPress admin.', 'memberlite' ); ?></p>
 	</div>

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -113,6 +113,10 @@ $memberlite_is_child      = is_child_theme();
 		</script>
 		<?php } ?>
 		<hr />
-		<p><?php esc_html_e( 'To import WordPress content such as posts, pages, and media, use the built-in WordPress tools located at Tools > Import in the WordPress admin.', 'memberlite' ); ?></p>
+		<p><?php printf(
+				/* translators: %s: link to the WordPress Tools > Import admin page */
+				esc_html__( 'To import WordPress content such as posts, pages, headers, footers, and media, use the built-in WordPress %s page.', 'memberlite' ),
+				'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools &gt; Import', 'memberlite' ) . '</a>'
+			); ?></p>
 	</div>
 </div>

--- a/functions.php
+++ b/functions.php
@@ -72,6 +72,11 @@ function memberlite_admin_enqueue_scripts() {
 
 		wp_register_script( 'memberlite_admin_js', MEMBERLITE_URL . '/js/admin.js', [ 'jquery' ], MEMBERLITE_VERSION, true );
 		wp_enqueue_script( 'memberlite_admin_js' );
+
+		if ( isset( $_GET['page'] ) && 'memberlite-tools' === $_GET['page'] && is_child_theme() ) {
+			wp_register_script( 'memberlite_admin_tools_js', MEMBERLITE_URL . '/js/admin-tools.js', [], MEMBERLITE_VERSION, true );
+			wp_enqueue_script( 'memberlite_admin_tools_js' );
+		}
 	}
 
 }

--- a/js/admin-tools.js
+++ b/js/admin-tools.js
@@ -1,0 +1,33 @@
+/**
+ * Admin JS for Memberlite Tools page.
+ *
+ * Handles the import source toggle on the Tools > Import Settings section
+ * when a child theme is active.
+ *
+ * @since TBD
+ */
+( function() {
+	const radios= document.querySelectorAll( 'input[name="memberlite_import_source"]' ),
+		fileRow       = document.getElementById( 'memberlite-import-file-row' ),
+		menusRow      = document.getElementById( 'memberlite-import-menus-row' ),
+		actionField   = document.getElementById( 'memberlite-import-action' ),
+		fileInput     = document.getElementById( 'memberlite-import-file' );
+
+	if ( ! radios.length ) {
+		return;
+	}
+
+	function updateMode( mode ) {
+		var isClone           = ( mode === 'clone' );
+		fileRow.style.display  = isClone ? 'none' : '';
+		menusRow.style.display = isClone ? 'none' : '';
+		fileInput.disabled     = isClone;
+		actionField.value      = isClone ? 'memberlite_clone_parent_theme_settings' : 'memberlite_import_theme_settings';
+	}
+
+	Array.prototype.forEach.call( radios, function( radio ) {
+		radio.addEventListener( 'change', function() {
+			updateMode( this.value );
+		} );
+	} );
+}() );


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the ability to clone theme settings from a Memberlite parent theme to child theme via our Memberlite > Tools > Import Theme Settings tools. This can technically already be done if you're on an active Memberlite theme with your customizations, use our export tool, then activate the child theme and import the file, but if you're already on a child theme, you might've made some changes already and forgot there are some things you wanted from the parent. It's a back-and-forth export/import process versus having an option to detect you're on a child theme, and allowing you to import without having the swap themes.

Nothing's changed with the file import process. If we detect a child theme, some helper text/descriptions change, the file import changes from a checkbox to a radio, and Donna can choose between importing from a file or importing from a parent theme. I've also added some JS to show/hide the file field for a better UX.

<img width="1172" height="760" alt="image" src="https://github.com/user-attachments/assets/9dfcd6f7-d3db-42a7-afae-3f50a3d54b51" />

## How to test the changes in this Pull Request:

### Setup (do once)

- Have the Memberlite parent theme active with customized colors, fonts, layout, menus assigned, and Additional CSS
- Have a Memberlite child theme active with its own menus assigned to locations (different from parent's)
- Export a settings file from the parent via **Appearance > Memberlite > Tools > Export**

---

### Import from File (regression)

- [ ] 1. On the child theme with "Import from file" selected, submit with no file chosen — expect the "No file was uploaded" error notice
- [ ] 2. Upload a non-JSON or invalid file — expect the "does not appear to be a valid Memberlite settings file" error notice
- [ ] 3. Upload a valid export file with **"Replace menus" unchecked** — verify colors/fonts/layout applied, and that imported menus were added as new menus without removing existing ones
- [ ] 4. Upload the same file with **"Replace menus" checked** — verify existing menus were replaced by the imported ones
- [ ] 5. Upload a valid export file on the parent theme (non-child) — confirm the radio buttons for import source are not shown and the import works as before

---

### Clone from Parent (new feature)

- [ ] 6. On the child theme, select "Import settings from Memberlite parent theme" and submit — verify the "Parent theme settings were cloned" success notice appears
- [ ] 7. Go to Customizer — confirm colors, fonts, layout, and Additional CSS now match the parent
- [ ] 8. Go to **Appearance > Menus** — confirm the child's menu location assignments are unchanged (menus still assigned to the same locations as before the clone)
- [ ] 9. On a site where the parent has no customizations (fresh parent), attempt clone — expect the "No settings were found on the parent theme" error notice
- [ ] 10. Switch to the parent theme directly (non-child) — confirm the "Import settings from Memberlite parent theme" radio option is not shown

## Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added a “clone from parent theme” import mode on the Memberlite Tools page when a child theme is active, allowing users to copy parent theme Customizer/theme-mod settings into the child theme. Also refactored theme-mod application logic into a shared helper and added a small admin JS file to toggle the import mode UI.
