### PR TITLE
Reverting approach for 16:9 aspect ratio to not add a new image size; correcting via CSS that was missed

### DIFF
--- a/components/post/content-grid.php
+++ b/components/post/content-grid.php
@@ -14,9 +14,9 @@ global $memberlite_defaults; ?>
 	<a class="post-thumbnail-link" href="<?php echo esc_url( get_permalink() ); ?>">
 		<?php
 			// Use the dedicated banner image if available, otherwise fall back to the featured image.
-			$grid_image = memberlite_get_banner_image( get_the_ID(), 'memberlite-16x9', false, array( 'class' => 'aligncenter' ) );
+			$grid_image = memberlite_get_banner_image( get_the_ID(), 'large', false, array( 'class' => 'aligncenter' ) );
 			if ( empty( $grid_image ) ) {
-				$grid_image = get_the_post_thumbnail( get_the_ID(), 'memberlite-16x9', array( 'class' => 'aligncenter' ) );
+				$grid_image = get_the_post_thumbnail( get_the_ID(), 'large', array( 'class' => 'aligncenter' ) );
 			}
 			if ( ! empty( $grid_image ) ) {
 				echo $grid_image; // WPCS: xss ok.

--- a/functions.php
+++ b/functions.php
@@ -236,7 +236,6 @@ if ( ! function_exists( 'memberlite_setup' ) ) :
 		add_image_size( 'memberlite-banner', 793, 200, true, array( 'center', 'center' ) );
 		add_image_size( 'memberlite-fullwidth', 1170, 1200, false, array( 'center', 'center' ) );
 		add_image_size( 'memberlite-masthead', 1600, 300, true, array( 'center', 'center' ) );
-		add_image_size( 'memberlite-16x9', 960, 540, true, array( 'center', 'center' ) );
 
 		// Add support for Block Styles.
 		add_theme_support( 'wp-block-styles' );

--- a/src/scss/components/_grid-list.scss
+++ b/src/scss/components/_grid-list.scss
@@ -61,19 +61,19 @@
 		align-items: center;
 		display: flex;
 		margin: calc(-1 * var(--wp--preset--spacing--10));
-		max-height: 180px;
 		overflow: hidden;
 
-		&:hover,
-		&:focus,
-		&:active {
-			filter: unset;
+		&:has(img) {
+			aspect-ratio: 16 / 9;
+			display: block;
 		}
 
-		// Duplicate rule in original merged into one block
 		.wp-post-image {
 			display: block;
+			height: 100%;
 			margin-bottom: 0;
+			object-fit: cover;
+			width: 100%;
 		}
 
 		// Fallback placeholder when no thumbnail exists
@@ -84,7 +84,7 @@
 				color-mix(in srgb, var(--memberlite-color-text) 20%, transparent)
 			);
 			display: flex;
-			height: 180px;
+			height: 218px;
 			justify-content: center;
 			width: 100%;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
@RachelRVasquez has a previous commit to add a new image size as a way to make the grid view of posts enforce a 16:9 aspect ratio.

That PR didn't not completely address the 16:9 requirement - there was still the CSS max-height property on the `a.post-thumbnail-link` item.

A better approach for this grid image sizing is to use purely CSS. This approach means that we won't be creating unnecessary image sizes in the uploads folder and that the aspect ratio can more easily be adjusted for the grid items using CSS alone, rather than a child theme component override.

This PR removes the added image size and puts the called image size back to the original (large). The aspect ratio is enforced via CSS. In the case of no post thumbnail, the placeholder / empty fallback is also set to have a "close as possible" 16:9 aspect ratio as well.
