### PR TITLE
Removing unnecessary filter unset property; We are no longer using a filter on image hover

### DIFF
--- a/src/scss/structure/_header.scss
+++ b/src/scss/structure/_header.scss
@@ -57,9 +57,6 @@
 		a.custom-logo-link {
 			display: block;
 
-			&:hover {
-				filter: unset;
-			}
 			&:focus {
 				outline: none;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR removes an unnecessary property that was copied in when Memberlite moved to scss over css. We are no longer adding a filter property to images on hover, so the "unset" in this file was unnecessary code.
