### PR TITLE
Logic to allow import/export to support the site icon and custom logo/site logo

### DIFF
--- a/adminpages/tools.php
+++ b/adminpages/tools.php
@@ -125,7 +125,7 @@ function memberlite_export_theme_settings() {
 
 		/**
 		 * Filter the option keys to export when exporting Memberlite theme settings.
-		 * By default, we export the site icon, custom sidebars, and sidebar assignments for custom post types.
+		 * By default, we export the site title, tagline, custom sidebars, and sidebar assignments for custom post types.
 		 *
 		 * Note: This same filter is used for resetting options in memberlite_reset_theme_settings().
 		 *
@@ -155,6 +155,40 @@ function memberlite_export_theme_settings() {
 
 		if ( function_exists( 'wp_get_custom_css' ) ) {
 			$data['wp_css'] = wp_get_custom_css();
+		}
+
+		// Export attachment references (site icon, custom logo) with absolute URLs so they can be resolved on import.
+		$attachments_data = array();
+
+		$site_icon_id = (int) get_option( 'site_icon' );
+		if ( $site_icon_id ) {
+			$site_icon_url = wp_get_attachment_url( $site_icon_id );
+			if ( $site_icon_url ) {
+				$attachments_data['site_icon'] = array(
+					'id'       => $site_icon_id,
+					'url'      => $site_icon_url,
+					'filename' => basename( wp_parse_url( $site_icon_url, PHP_URL_PATH ) ),
+				);
+			}
+		}
+
+		// Strip the raw ID only after capturing a portable reference, so a broken logo isn't silently dropped.
+		$custom_logo_id = (int) get_theme_mod( 'custom_logo' );
+		if ( $custom_logo_id ) {
+			$custom_logo_url = wp_get_attachment_url( $custom_logo_id );
+			if ( $custom_logo_url ) {
+				$attachments_data['custom_logo'] = array(
+					'id'       => $custom_logo_id,
+					'url'      => $custom_logo_url,
+					'filename' => basename( wp_parse_url( $custom_logo_url, PHP_URL_PATH ) ),
+				);
+				// Only strip once we've captured a resolvable reference — otherwise a broken logo would disappear silently.
+				unset( $data['mods']['custom_logo'] );
+			}
+		}
+
+		if ( ! empty( $attachments_data ) ) {
+			$data['attachments'] = $attachments_data;
 		}
 	}
 
@@ -277,7 +311,8 @@ function memberlite_import_theme_settings() {
 	check_admin_referer( 'memberlite_import_theme_settings', 'memberlite_import_theme_settings_nonce' );
 
 	// Validate file upload.
-	if ( empty( $_FILES['memberlite_import_file']['tmp_name'] ) || ! is_uploaded_file( $_FILES['memberlite_import_file']['tmp_name'] ) ) {
+	$upload_error = isset( $_FILES['memberlite_import_file']['error'] ) ? (int) $_FILES['memberlite_import_file']['error'] : UPLOAD_ERR_NO_FILE;
+	if ( UPLOAD_ERR_OK !== $upload_error || empty( $_FILES['memberlite_import_file']['tmp_name'] ) || ! is_uploaded_file( $_FILES['memberlite_import_file']['tmp_name'] ) ) {
 		memberlite_import_settings_redirect( 'no_file' );
 	}
 
@@ -307,6 +342,10 @@ function memberlite_import_theme_settings() {
 	if ( isset( $data['mods'] ) && is_array( $data['mods'] ) ) {
 		// Clear existing mods so we don't leave stale ones behind.
 		remove_theme_mods();
+
+		// Drop mods whose values are source-site IDs that wouldn't resolve here.
+		// custom_logo is rebuilt via $data['attachments']; nav_menu_locations is rebuilt from imported menus.
+		unset( $data['mods']['custom_logo'], $data['mods']['nav_menu_locations'] );
 
 		// Get all color setting keys.
 		$color_keys = memberlite_get_color_setting_keys();
@@ -355,7 +394,7 @@ function memberlite_import_theme_settings() {
 		set_theme_mod( 'memberlite_color_scheme', $final_scheme );
 	}
 
-	// Restore extra options (site_icon, sidebars, etc.), if present.
+	// Restore extra options (sidebars, blogname, etc.), if present.
 	if ( ! empty( $data['options'] ) && is_array( $data['options'] ) ) {
 		foreach ( $data['options'] as $key => $value ) {
 			update_option( $key, $value );
@@ -365,6 +404,29 @@ function memberlite_import_theme_settings() {
 	// Restore Additional CSS if we exported it.
 	if ( ! empty( $data['wp_css'] ) && function_exists( 'wp_update_custom_css_post' ) ) {
 		wp_update_custom_css_post( $data['wp_css'] );
+	}
+
+	// Resolve attachment references (site_icon, custom_logo) to local attachment IDs.
+	if ( ! empty( $data['attachments'] ) && is_array( $data['attachments'] ) ) {
+		foreach ( $data['attachments'] as $target => $info ) {
+			if ( empty( $info['url'] ) ) {
+				continue;
+			}
+
+			$source_url  = esc_url_raw( $info['url'] );
+			$id_hint     = isset( $info['id'] ) ? (int) $info['id'] : 0;
+			$resolved_id = memberlite_resolve_imported_attachment( $source_url, $id_hint );
+
+			if ( ! $resolved_id ) {
+				continue;
+			}
+
+			if ( 'site_icon' === $target ) {
+				update_option( 'site_icon', $resolved_id );
+			} elseif ( 'custom_logo' === $target ) {
+				set_theme_mod( 'custom_logo', $resolved_id );
+			}
+		}
 	}
 
 	// Import navigation menus if present.
@@ -534,6 +596,103 @@ function memberlite_import_settings_redirect( $code ) {
 }
 
 /**
+ * Resolve an imported attachment reference to a local attachment ID.
+ *
+ * Tries, in order: existing ID with matching filename, media library filename match,
+ * sideload from the absolute URL.
+ *
+ * @since TBD
+ *
+ * @param string $url     Absolute URL of the source attachment.
+ * @param int    $id_hint Attachment ID from the source site (optional).
+ * @return int Resolved attachment ID, or 0 if it could not be resolved.
+ */
+function memberlite_resolve_imported_attachment( $url, $id_hint = 0 ) {
+	$filename = basename( wp_parse_url( $url, PHP_URL_PATH ) );
+	if ( empty( $filename ) ) {
+		return 0;
+	}
+
+	// 1. Same ID locally with matching filename — handles re-importing on the same site.
+	if ( $id_hint > 0 && 'attachment' === get_post_type( $id_hint ) && wp_attachment_is_image( $id_hint ) ) {
+		$existing_file = get_attached_file( $id_hint );
+		if ( $existing_file && basename( $existing_file ) === $filename ) {
+			return $id_hint;
+		}
+	}
+
+	// 2. Find any attachment in the media library with the same filename.
+	// Require an image so we don't bind a logo/icon to an unrelated same-named PDF, ZIP, etc.
+	$found_id = memberlite_find_attachment_by_filename( $filename );
+	if ( $found_id && wp_attachment_is_image( $found_id ) ) {
+		return $found_id;
+	}
+
+	// 3. Sideload from the absolute URL.
+	// Reject anything that isn't an http(s) URL — admin-gated, but we don't want file://, ftp://, etc. fetched.
+	$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+	if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+		return 0;
+	}
+
+	require_once ABSPATH . 'wp-admin/includes/media.php';
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+
+	$tmp = download_url( $url );
+	if ( is_wp_error( $tmp ) ) {
+		return 0;
+	}
+
+	$file_array = array(
+		'name'     => $filename,
+		'tmp_name' => $tmp,
+	);
+
+	$new_id = media_handle_sideload( $file_array, 0 );
+
+	if ( is_wp_error( $new_id ) ) {
+		@unlink( $tmp );
+		return 0;
+	}
+
+	// Reject anything that came back as a non-image — we're only resolving site_icon / custom_logo here.
+	if ( ! wp_attachment_is_image( $new_id ) ) {
+		wp_delete_attachment( $new_id, true );
+		return 0;
+	}
+
+	return (int) $new_id;
+}
+
+/**
+ * Look up an attachment by its filename via the _wp_attached_file meta.
+ *
+ * @since TBD
+ *
+ * @param string $filename The filename to search for (e.g. "icon-512.png").
+ * @return int Attachment ID, or 0 if not found.
+ */
+function memberlite_find_attachment_by_filename( $filename ) {
+	global $wpdb;
+
+	$like = '%/' . $wpdb->esc_like( $filename );
+
+	$id = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT post_id FROM {$wpdb->postmeta}
+			WHERE meta_key = '_wp_attached_file'
+			AND ( meta_value = %s OR meta_value LIKE %s )
+			LIMIT 1",
+			$filename,
+			$like
+		)
+	);
+
+	return $id ? (int) $id : 0;
+}
+
+/**
  * Handle Memberlite theme settings reset.
  *
  * @since 6.1
@@ -551,6 +710,9 @@ function memberlite_reset_theme_settings() {
 
 	// Reset all theme mods.
 	remove_theme_mods();
+
+	// Reset the site_logo.
+	delete_option( 'site_logo' );
 
 	/**
 	 * Filter the option keys to reset when resetting Memberlite theme settings.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

### Changes proposed in this Pull Request:
Restores `site_icon` to the theme settings import/export (it was removed in #307 because a bare attachment ID won't resolve across sites) and adds proper cross-site handling for `custom_logo` (which had the same bare-ID problem but was being silently exported via `get_theme_mods()`).

Both fields now travel as portable attachment references with the absolute source URL, so the import can rebuild them on the destination — even on a fresh install with no shared media library.

**Export (`memberlite_export_theme_settings`)**
- New top-level `attachments` block in the JSON containing `site_icon` and/or `custom_logo`, each as `{ id, url, filename }`.
- `custom_logo` is stripped from `mods` once a resolvable reference is captured, so the raw source-site ID can't clobber the resolved one on import.

**Import (`memberlite_import_theme_settings`)**
- New `memberlite_resolve_imported_attachment( $url, $id_hint )` helper resolves each reference via a 3-step  ladder: same-ID-with-matching-filename → media library filename lookup → `download_url()` + `media_handle_sideload()` from the absolute URL.
- All three steps verify `wp_attachment_is_image()` so a logo/icon can't accidentally bind to an unrelated  same-named file.
- SSRF guard: only `http`/`https` URLs are sideloaded.
- `custom_logo` and `nav_menu_locations` are stripped from `$data['mods']` before the mods loop runs (foreign  IDs that would otherwise survive if resolution failed or menus weren't exported).
- Upload validation now checks `UPLOAD_ERR_OK` so "file too large" no longer surfaces as a generic "no file" error.

**Reset (`memberlite_reset_theme_settings`)**
- Now deletes the `site_logo` option after `remove_theme_mods()`. WordPress's `theme_mod_custom_logo` filter reads `site_logo` and overrides the (now-removed) theme mod, so without this the logo persisted after a "reset."

### How to test the changes in this Pull Request:

1. On Site A, set a Site Icon (Customizer → Site Identity) and a Custom Logo, then export theme settings (Memberlite → Tools → Export). Open the JSON and confirm there's an `attachments` block with `site_icon` and `custom_logo` entries, each containing `id`, `url`, and `filename`. Confirm `mods.custom_logo` is **not**  present.
2. On Site B (a different install, no shared media), import that JSON. Confirm:
- The browser tab favicon updates to the imported icon.
- The header logo renders correctly.
- The media library contains the newly sideloaded image(s).
3. On the same Site B, re-import the same JSON. Confirm no duplicate media is created (the filename lookup should reuse the attachment from step 2).
4. Manually edit a JSON export and change one of the `attachments[*].url` values to `file:///etc/passwd` or `ftp://...`. Import. Confirm the import succeeds for everything else and the malformed entry is skipped (no fetch attempted).
5. Set a custom logo, then run Memberlite → Tools → Reset. Confirm the logo is gone from the front end (regression check for the `site_logo` option issue).
6. Try uploading a too-large file at the Import form (or set PHP `upload_max_filesize` to a tiny value temporarily). Confirm you get the "no file" notice rather than a silent failure or PHP warning.
7. Import a JSON exported from a pre-7.1.X build (no `attachments` block, with `custom_logo` in `mods`). Confirm the import completes without errors and doesn't apply a stale foreign-site logo ID.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added support for export/import of the site icon and custom logo, with cross-site resolution via filename match or sideload from the source URL.