### PR TITLE
Removing dead code and incorrect hover color for outline button style

### DIFF
--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -196,15 +196,6 @@ hr.wp-block-separator {
 	}
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link {
-	background: transparent;
-
-	&:hover {
-		background-color: var(--wp--preset--color--buttons);
-		color: var(--wp--preset--color--base);
-	}
-}
-
 // -----------------------------------------------------------------------------
 // Comments Block
 // -----------------------------------------------------------------------------

--- a/theme.json
+++ b/theme.json
@@ -1510,15 +1510,6 @@
 								"bottom": "calc( var(--wp--preset--spacing--10) / 2)",
 								"left": "var(--wp--preset--spacing--10)"
 							}
-						},
-						":hover": {
-							"color": {
-								"background": "currentColor",
-								"text": "var(--wp--preset--color--base)"
-							},
-							"border": {
-								"color": "currentColor"
-							}
 						}
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow-up to #304, which partially fixed the outline button block style. That PR removed the hardcoded default-state `border-color` and `color` overrides so user-picked colors would show through, but left the `:hover` rule hardcoded to `--wp--preset--color--buttons`.

This meant that, on hover, the outline button always filled with the theme's default button color and reverted the user's picked color (i.e. it visually behaved like a regular Fill button).

Rather than reintroduce a hover state that can't reliably honor a custom-picked color (see notes below), this PR removes outline-specific hover handling entirely so the outline style is purely a resting visual treatment (we likewise do not attempt to modify the default button style on hover if the background is a custom color).

- Removed the `.wp-block-button.is-style-outline .wp-block-button__link` block from `src/scss/blocks/_blocks.scss` — both the `:hover` rule (the bug) and the `background: transparent` rule (redundant with WordPress core's `.is-style-outline:not(.has-background)` rule, and was incorrectly forcing transparent even when a user explicitly picked a background color).

- Removed the now-dead `:hover` block from `styles.blocks.core/button.variations.outline` in `theme.json`. WordPress 6.9 silently drops `:hover` defined inside a block style variation (see [Trac #64094](https://core.trac.wordpress.org/ticket/64094)), so this code was never emitted; leaving it in place would also have surfaced a `currentColor` self-reference bug if/when Trac #64094 is fixed upstream.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
