### PR TITLE
Perform a one-time theme mod copy from parent to child on child theme activation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -565,6 +565,9 @@ require_once get_template_directory() . '/inc/customizer.php';
 /* Custom functions that act independently of the theme templates. */
 require_once get_template_directory() . '/inc/extras.php';
 
+/* One-time clone of parent settings on child theme activation. */
+require_once get_template_directory() . '/inc/child-theme-activation.php';
+
 /* Deprecated hooks, filters and functions. */
 require_once get_template_directory() . '/inc/deprecated.php';
 

--- a/inc/child-theme-activation.php
+++ b/inc/child-theme-activation.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * One-time clone of Memberlite parent theme settings to a freshly activated child theme.
+ *
+ * When a user activates a Memberlite child theme that doesn't yet have its own
+ * customizations, we copy the parent's Customizer settings (theme_mods) and
+ * Additional CSS into the child so the site appearance doesn't shift dramatically.
+ *
+ * The gate is data-driven: if the child already has meaningful theme_mods, we
+ * leave it alone. That way this naturally runs only once per child theme.
+ *
+ * @package Memberlite
+ * @since TBD
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * On child theme activation, copy parent Memberlite settings to the child if the
+ * child has no meaningful theme_mods of its own yet.
+ *
+ * @since TBD
+ */
+function memberlite_maybe_clone_parent_settings_on_activation() {
+	// Only act when a child theme of Memberlite is now active.
+	if ( ! is_child_theme() || 'memberlite' !== get_template() ) {
+		return;
+	}
+
+	$child_stylesheet = get_stylesheet();
+
+	// Bail if the child already has its own customizations.
+	// Ignore noise that WP / plugins add automatically: numeric-keyed sentinels,
+	// WP-seeded `nav_menu_locations`, and auto-created `custom_css_post_id`.
+	$child_mods = get_option( 'theme_mods_' . $child_stylesheet, null );
+	if ( is_array( $child_mods ) ) {
+		$ignored = array( 'nav_menu_locations', 'custom_css_post_id' );
+		foreach ( $child_mods as $key => $value ) {
+			if ( ! is_string( $key ) || in_array( $key, $ignored, true ) ) {
+				continue;
+			}
+			// Real Customizer setting found. Leave the child alone.
+			return;
+		}
+	}
+
+	// Pull parent settings.
+	$parent_mods = get_option( 'theme_mods_memberlite', null );
+	if ( ! is_array( $parent_mods ) || empty( $parent_mods ) ) {
+		return;
+	}
+
+	// Strip keys that shouldn't cross theme boundaries.
+	// `custom_css_post_id` points to a parent-scoped CSS post; we handle CSS separately below.
+	// `memberlite_darkcss` is a deprecated mod.
+	$skip_keys = array( 'custom_css_post_id', 'memberlite_darkcss' );
+	foreach ( array_keys( $parent_mods ) as $key ) {
+		if ( ! is_string( $key ) ) {
+			continue;
+		}
+		if ( in_array( $key, $skip_keys, true ) || 0 === strpos( $key, '_transient_' ) ) {
+			unset( $parent_mods[ $key ] );
+		}
+	}
+
+	if ( empty( $parent_mods ) ) {
+		return;
+	}
+
+	// One write instead of N set_theme_mod() calls. This MUST run before the CSS copy
+	// below: wp_update_custom_css_post() will set_theme_mod( 'custom_css_post_id', ... )
+	// on the active theme, and a wholesale option write here would clobber it.
+	update_option( 'theme_mods_' . $child_stylesheet, $parent_mods );
+
+	// Copy Additional CSS from the parent into the child's own CSS post.
+	$parent_css = wp_get_custom_css( 'memberlite' );
+	if ( ! empty( $parent_css ) && function_exists( 'wp_update_custom_css_post' ) ) {
+		wp_update_custom_css_post( $parent_css, array( 'stylesheet' => $child_stylesheet ) );
+	}
+
+	// Flag the admin notice so the user knows what happened.
+	set_transient( 'memberlite_cloned_parent_settings', 1, HOUR_IN_SECONDS );
+}
+add_action( 'after_switch_theme', 'memberlite_maybe_clone_parent_settings_on_activation' );
+
+/**
+ * Show a one-time admin notice after we cloned parent theme settings into a child.
+ *
+ * @since TBD
+ */
+function memberlite_cloned_parent_settings_notice() {
+	if ( ! current_user_can( 'edit_theme_options' ) ) {
+		return;
+	}
+
+	if ( ! get_transient( 'memberlite_cloned_parent_settings' ) ) {
+		return;
+	}
+
+	delete_transient( 'memberlite_cloned_parent_settings' );
+
+	echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Memberlite automatically copied your parent theme settings (colors, fonts, layout, menus, and Additional CSS) to this child theme so your site keeps the same look.', 'memberlite' ) . '</p></div>';
+}
+add_action( 'admin_notices', 'memberlite_cloned_parent_settings_notice' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR will perform a one-time migration of theme mods from the parent to child theme when a new Memberlite child theme is activated in a site. This solves the "I should have used a child theme" moment: a user activates a Memberlite child theme on a site they've been customizing for months, and the whole display shifts because none of their parent customizations carry over.

A previous approach to create tooling for this was done in PR #308. That approach would have relied on the site builder knowing that there is a tool for importing from a parent. This PR makes the carry-over automatic and silent. On `after_switch_theme`, if a Memberlite child theme is now active **and** it has no meaningful theme mods of its own yet, we copy the parent's `theme_mods_memberlite` and Additional CSS into the child. One file, one hook, no UI. A one-shot admin notice afterward so the user knows what happened.

### How "one-time" works
The gate is data-driven, not flag-based: we only slurp when the child's `theme_mods_{stylesheet}` option contains nothing beyond the WP-seeded `nav_menu_locations` and auto-created `custom_css_post_id`. Once the child has any real Customizer setting, this code is a permanent no-op for that child. No `memberlite_already_cloned` option to migrate, no "have we done this yet?" bookkeeping.

### What gets copied
- All theme mods from the parent (colors, fonts, layout, menu locations, etc.)
- Additional CSS (`wp_update_custom_css_post()` into the child's stylesheet scope)

### What gets skipped
- `custom_css_post_id` (parent-scoped; we let core re-create the child's via `wp_update_custom_css_post()`)
- `memberlite_darkcss` (deprecated mod)
- Non-string array keys and `_transient_*` prefixes (defensive against legacy/plugin artifacts)

### Why this approach vs. a Tools-page importer
A Tools-page importer (#308) is more flexible but the "I switched to a child" problem is infrequent enough that burying a button in `Appearance > Memberlite > Tools` is undiscoverable for the people who need it most. The vast majority of the time, the right behavior is "make my site keep looking the way it did," and we have enough signal at activation time to just do that.

## How to test the changes in this Pull Request:

### Setup
- Memberlite parent active with customizations (colors, fonts, layout, Additional CSS, menus assigned to locations)
- A Memberlite child theme installed but never activated (or with its `theme_mods_{child-slug}` row deleted from `wp_options`)

### Golden path: slurp on first activation

- [x] 1. Activate the child theme. Load any admin page.
- [x] 2. Verify the success notice appears: "Memberlite automatically copied your parent theme settings..."
- [x] 3. Open the front-end: colors, fonts, layout, Additional CSS, and menu locations should match the parent.
- [x] 4. Inspect `wp_options` → `theme_mods_{child-slug}`. Should be populated with parent's mods (minus `custom_css_post_id` and `memberlite_darkcss`).

### Gate: don't re-slurp once the child has customizations

- [x] 5. Switch back to parent, then activate the child again. The notice should NOT appear and child mods should be untouched.
- [x] 6. Change one Customizer setting on the child (e.g., primary color). Switch to parent, then back to child. Notice should NOT appear; the child's customizations should survive.

### Negative gates

- [x] 7. Activate the parent theme directly (not from a child). Nothing happens, no notice.
- [x] 8. Activate a non-Memberlite child theme (parent ≠ `memberlite`). Nothing happens, no notice.
- [x] 9. With parent that has zero customizations, activate child. On a non-Memberlite parent theme, the theme mods would be empty with the exception of `custom_css_post_id`, but since Memberlite sets default theme mods with the `memberlite_get_defaults()` function, Memberlite will have theme mods even if the Customizer is never touched on the admin. We _do_ want these copied to the child theme, so confirm that the notice appears, and that the theme mods are copied from parent to child in the database.

### Edge cases

- [x] 10. Confirm the new child's Additional CSS post is its own (separate post ID from the parent's) by editing the child's Additional CSS in Customizer and verifying the parent's CSS is unchanged.
- [x] 11. Confirm `custom_css_post_id` in the child's theme_mods points to the new child-scoped post, not the parent's (this is  the load-bearing write-order behavior documented inline).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* FEATURE: Now automatically copying the parent theme's Customizer settings and Additional CSS into the child on first child theme activation.