### PR TITLE
Fixing in loop banner to display as intended behind the entry header; not hyperlinking in this case

### DIFF
--- a/components/post/entry-header.php
+++ b/components/post/entry-header.php
@@ -18,9 +18,7 @@ if ( $content_archives != 'grid' || is_search() ) {
 
 	if ( ! empty( $memberlite_get_banner_image_src ) ) { ?>
 		<div class="entry-banner">
-			<a href="<?php echo esc_url( get_permalink() ); ?>" tabindex="-1" aria-hidden="true">
-				<img class="banner-image" src="<?php echo esc_url( $memberlite_get_banner_image_src[0] ); ?>" alt="" aria-hidden="true" />
-			</a>
+			<img class="banner-image" src="<?php echo esc_url( $memberlite_get_banner_image_src[0] ); ?>" alt="" aria-hidden="true" />
 	<?php } ?>
 
 <?php } ?>

--- a/src/scss/structure/_content.scss
+++ b/src/scss/structure/_content.scss
@@ -20,6 +20,15 @@
 		margin: 0 0 var(--wp--preset--spacing--20) 0;
 		overflow: hidden;
 		position: relative;
+
+		img.banner-image {
+			height: 100%;
+			left: 0;
+			object-fit: cover;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 	}
 
 	// When a banner image is present, overlay the entry header


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Reverting the hyperlink wrapping the image that is meant to be placed as a background image on the loop entry title area. 

Also resolving the CSS so that the image is displayed properly as the background image on the loop entry title area. This was lost styling in the move to SCSS commits.

**Before**
<img width="774" height="692" alt="Screenshot 2026-06-03 at 7 20 41 AM" src="https://github.com/user-attachments/assets/07b5483c-2807-4499-be98-4b7f8c74fe2e" />

**After**
<img width="849" height="436" alt="Screenshot 2026-06-04 at 7 00 44 AM" src="https://github.com/user-attachments/assets/e34c9a92-2b49-41d3-a3fe-213038e8ac73" />

### How to test the changes in this Pull Request:

1. Set your Posts and Archives > Featured Images setting to Show Banner Only or Show Banner and Thumbnail
2. Without this PR, see that it displays above the title area.
3. With this PR, see that it displays as a background image on the loop post's title area as intended before the SCSS changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG: Fixed display issue for title area background banner image in posts loop.
