### PR TITLE
Correct fix for the bbPress search results to inherit assigned forum post type sidebar, if specified

### DIFF
--- a/inc/integrations/bbpress.php
+++ b/inc/integrations/bbpress.php
@@ -62,10 +62,18 @@ add_filter( 'bbp_no_breadcrumb', '__return_true' );
  *
  * @param array $widget_areas Array of sidebar IDs.
  */
-function memberlite_bbpress_widget_areas( $widget_areas ) {
-	if ( is_bbpress() && bbp_is_search_results() ) {
-		$widget_areas = array( memberlite_get_default_sidebar_by_post_type( 'forum' ) );
+function memberlite_bbpress_search_widget_areas( $widget_areas ) {
+	// Only modify widget areas for bbPress search results page, otherwise return the default widget areas.
+	if ( ! bbp_is_search() ) {
+		return $widget_areas;
 	}
+
+	// Get the assigned sidebar for the 'forum' post type.
+	$forum_sidebar = memberlite_get_default_sidebar_by_post_type( 'forum' );
+	if ( 'memberlite_sidebar_default' !== $forum_sidebar ) {
+		return array( $forum_sidebar );
+	}
+
 	return $widget_areas;
 }
-add_filter( 'memberlite_get_widget_areas', 'memberlite_bbpress_widget_areas' );
+add_filter( 'memberlite_get_widget_areas', 'memberlite_bbpress_search_widget_areas' );

--- a/inc/integrations/bbpress.php
+++ b/inc/integrations/bbpress.php
@@ -56,3 +56,16 @@ add_filter( 'bbp_before_get_breadcrumb_parse_args', 'memberlite_bbp_breadcrumb' 
 
 /* Removes bbp_breadcrumb from bbpress templates */
 add_filter( 'bbp_no_breadcrumb', '__return_true' );
+
+/**
+ * Fix so that bbPress search results page uses the assigned 'forum' post type sidebar, if specified, instead of the default sidebar.
+ *
+ * @param array $widget_areas Array of sidebar IDs.
+ */
+function memberlite_bbpress_widget_areas( $widget_areas ) {
+	if ( is_bbpress() && bbp_is_search_results() ) {
+		$widget_areas = array( memberlite_get_default_sidebar_by_post_type( 'forum' ) );
+	}
+	return $widget_areas;
+}
+add_filter( 'memberlite_get_widget_areas', 'memberlite_bbpress_widget_areas' );

--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -374,11 +374,6 @@ function memberlite_get_widget_areas() {
 		}
 	}
 
-	// Special case for bbPress search results page.
-	if ( empty( $memberlite_custom_sidebar ) && function_exists( 'is_bbpress' ) && is_bbpress() && ! bbp_is_single_topic() ) {
-		$widget_areas = array( memberlite_get_default_sidebar_by_post_type( 'forum' ) );
-	}
-
 	// If no custom sidebar for this specific post and we're on a blog page, check if the blog page has one to inherit.
 	if ( empty( $memberlite_custom_sidebar ) && function_exists( 'memberlite_is_blog' ) && memberlite_is_blog() ) {
 		$posts_page = get_option( 'page_for_posts' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There was broken code in the sidebar logic of Memberlite to try to repair the bbPress "forum search" to also inherit a custom sidebar, if specified, for the forum post type.

The code there was incorrectly overriding all of bbPress, so in the case that the site owner did not specify a custom sidebar/set up a custom sidebar, it would show nothing.

This fix moves the custom logic into the bbPress compatibility file first. Then it targets specifically the search page, rather than a blanket rule for anything in bbPress.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Improved logic around bbPress search page to properly inherit the assigned `forum` post type sidebar.