### PR TITLE
Update text on our Import, Export, and Reset tool to mention headers and footers

### DIFF
--- a/adminpages/tools/export-settings.php
+++ b/adminpages/tools/export-settings.php
@@ -125,10 +125,12 @@ $menus = wp_get_nav_menus();
 			</p>
 		</form>
 		<hr />
-		<?php printf(
-		/* translators: %s: link to the WordPress Tools > Import admin page */
-			esc_html__( 'To export WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ),
-			'<a href="' . esc_url( admin_url( 'export.php' ) ) . '">' . esc_html__( 'Tools > Export', 'memberlite' ) . '</a>'
-		); ?>
+		<p><?php
+			printf(
+			/* translators: %s: link to the WordPress Tools > Export admin page */
+				wp_kses_post( __( 'To export WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ) ),
+				'<a href="' . esc_url( admin_url( 'export.php' ) ) . '">' . esc_html__( 'Tools > Export', 'memberlite' ) . '</a>'
+			);
+			?></p>
 	</div>
 </div>

--- a/adminpages/tools/export-settings.php
+++ b/adminpages/tools/export-settings.php
@@ -125,6 +125,10 @@ $menus = wp_get_nav_menus();
 			</p>
 		</form>
 		<hr />
-		<p><?php esc_html_e( 'To export WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress tools located at Tools > Export in the WordPress admin.', 'memberlite' ); ?></p>
+		<?php printf(
+		/* translators: %s: link to the WordPress Tools > Import admin page */
+			esc_html__( 'To export WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ),
+			'<a href="' . esc_url( admin_url( 'export.php' ) ) . '">' . esc_html__( 'Tools > Export', 'memberlite' ) . '</a>'
+		); ?>
 	</div>
 </div>

--- a/adminpages/tools/export-settings.php
+++ b/adminpages/tools/export-settings.php
@@ -125,6 +125,6 @@ $menus = wp_get_nav_menus();
 			</p>
 		</form>
 		<hr />
-		<p><?php esc_html_e( 'To export WordPress content such as posts, pages, and media, use the built-in WordPress tools located at Tools > Export in the WordPress admin.', 'memberlite' ); ?></p>
+		<p><?php esc_html_e( 'To export WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress tools located at Tools > Export in the WordPress admin.', 'memberlite' ); ?></p>
 	</div>
 </div>

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -56,6 +56,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</p>
 		</form>
 		<hr />
-		<p><?php esc_html_e( 'To import WordPress content such as posts, pages, and media, use the built-in WordPress tools located at Tools > Import in the WordPress admin.', 'memberlite' ); ?></p>
+		<p><?php esc_html_e( 'To import WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress tools located at Tools > Import in the WordPress admin.', 'memberlite' ); ?></p>
 	</div>
 </div>

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -56,6 +56,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</p>
 		</form>
 		<hr />
-		<p><?php esc_html_e( 'To import WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress tools located at Tools > Import in the WordPress admin.', 'memberlite' ); ?></p>
+		<?php printf(
+		/* translators: %s: link to the WordPress Tools > Import admin page */
+			esc_html__( 'To import WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ),
+			'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools > Import', 'memberlite' ) . '</a>'
+		); ?>
 	</div>
 </div>

--- a/adminpages/tools/import-settings.php
+++ b/adminpages/tools/import-settings.php
@@ -56,10 +56,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</p>
 		</form>
 		<hr />
-		<?php printf(
-		/* translators: %s: link to the WordPress Tools > Import admin page */
-			esc_html__( 'To import WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ),
-			'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools > Import', 'memberlite' ) . '</a>'
-		); ?>
+		<p><?php
+			printf(
+				wp_kses_post( __( 'To import WordPress content such as posts, pages, header variations, footer variations, and media, use the built-in WordPress %s page.', 'memberlite' ) ),
+				'<a href="' . esc_url( admin_url( 'import.php' ) ) . '">' . esc_html__( 'Tools > Import', 'memberlite' ) . '</a>'
+			);
+			?></p>
 	</div>
 </div>

--- a/adminpages/tools/reset.php
+++ b/adminpages/tools/reset.php
@@ -18,7 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="memberlite_section_inside">
 		<p><?php esc_html_e( 'Use this tool to reset Memberlite theme settings to their default values.', 'memberlite' ); ?> <strong><?php esc_html_e( 'This will overwrite your current Memberlite theme settings.', 'memberlite' ); ?></strong></p>
-		<p><?php esc_html_e( 'The reset will clear Memberlite Customizer settings (including logo, colors, typography, and layouts), Memberlite sidebar settings, the site icon, and any Additional CSS for the current theme.', 'memberlite' ); ?> <strong><?php esc_html_e( 'It will not delete any posts, pages, or media.', 'memberlite' ); ?></strong></p>
+		<p><?php esc_html_e( 'The reset will clear Memberlite Customizer settings (including logo, colors, typography, and layouts), Memberlite sidebar settings, the site icon, and any Additional CSS for the current theme.', 'memberlite' ); ?></p>
+		<p><strong><?php esc_html_e( 'It will not delete any posts, pages, navigation menus, header variations, footer variations, or media.', 'memberlite' ); ?></strong></p>
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return memberliteConfirmThemeReset();">
 			<p class="submit">
 				<?php wp_nonce_field( 'memberlite_reset_theme_settings', 'memberlite_reset_theme_settings_nonce' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated our `To import/export WordPress content such as posts, pages...` text to also include header and footer variations because those are also content. If they're set up in the Customizer, the settings can import/export, but without the actual content, it won't pull the headers/footers.

Also clarified in the **Reset Theme** section that the tool does not delete header/footer variations or navigation menus.

I've also wrapped the text directing people to use core's Import/Export tool with links so it's easier for them to get to the tool from ours.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated text on our Import/Export/Reset tool to mention and clarify header variations, footer variations, and navigation menus. Headers, footers, and navigation menus are content, so resetting will not delete them. Headers and footers need to be imported/exported with core's tool and are not included in our import/export process.
