### PR TITLE
Filter adjustments to the `memberlite_get_cpts` function

### DIFF
--- a/docs/customizer.md
+++ b/docs/customizer.md
@@ -69,15 +69,15 @@ add_filter( 'memberlite_customizer_cpts', function( array $cpts ): array {
 } );
 ```
 
-The filter receives an indexed array of CPT slugs and must return the same.
+The filter receives an indexed array of CPT slugs. It can return an indexed array, or a comma-separated string of slugs.
 
-**Guard behavior:** After the filter runs, Memberlite silently removes any slugs that are:
+**Guard behavior:** After the filter runs, Memberlite normalizes the return value and then silently removes any slugs that are:
 - Registered by the Memberlite parent theme itself (e.g. `memberlite_header`, `memberlite_footer`)
 - Not currently registered as a post type
 - Backed by a CPT with `show_ui => false` (internal/programmatic post types)
-- Not a non-empty string (e.g. empty strings, arrays, integers are stripped)
+- Not a non-empty string (e.g. empty strings, nested arrays, integers are stripped)
 
-If the filter callback returns a non-array, the return value is discarded and the pre-filter list (the auto-detected PMPro CPTs) is used as a fallback, so built-in CPTs are never lost due to a bad callback.
+If the filter callback returns something other than an array or string (e.g. `null`, `false`, an integer), it is treated as an empty array.
 
 This means passing an unregistered, internal, or malformed slug through the filter is safe — it will be dropped without an error.
 
@@ -85,10 +85,16 @@ This means passing an unregistered, internal, or malformed slug through the filt
 
 ### Disabling PMPro CPT Detection
 
-To prevent Memberlite from auto-detecting and adding PMPro CPTs, use the `memberlite_pmpro_cpt_layout_settings_enabled` filter. CPTs added via `memberlite_customizer_cpts` are unaffected — this only controls the built-in detection.
+To prevent Memberlite from adding PMPro CPTs, return an empty array or empty string from the `memberlite_customizer_cpts` filter. To replace them entirely with your own CPTs, return an array containing only those slugs.
 
 ```php
-add_filter( 'memberlite_pmpro_cpt_layout_settings_enabled', '__return_false' );
+// Remove all PMPro CPTs.
+add_filter( 'memberlite_customizer_cpts', '__return_empty_array' );
+
+// Remove all PMPro CPTs and substitute your own.
+add_filter( 'memberlite_customizer_cpts', function( $cpts ) {
+    return array( 'my_cpt_slug' );
+} );
 ```
 
 ### Settings per CPT
@@ -186,7 +192,7 @@ This is not a full list. Explore the codebase for more.
 
 ### `inc/extras.php`
 
-- `memberlite_get_customizer_cpts()` - Returns the indexed array of CPT slugs that receive per-type layout settings. Auto-detects known PMPro CPTs (unless disabled via `memberlite_pmpro_cpt_layout_settings_enabled`), applies the `memberlite_customizer_cpts` filter, then strips internal Memberlite CPTs, CPTs with `show_ui => false`, unregistered slugs, and any non-string or empty values. If the filter returns a non-array, falls back to the pre-filter list. Result is statically cached.
+- `memberlite_get_customizer_cpts()` - Returns the indexed array of CPT slugs that receive per-type layout settings. PMPro CPTs are passed as defaults to the `memberlite_customizer_cpts` filter. After the filter, normalizes the return value (string → array, unexpected types → empty array), then strips internal Memberlite CPTs, unregistered slugs, CPTs with `show_ui => false`, and any non-string or empty elements. Result is statically cached.
 
 - `memberlite_get_current_cpt_type()` - Returns the current CPT slug when on a CPT archive or single post that has Customizer settings, otherwise `null`. Used to resolve sidebar and columns ratio settings for both archive and single views.
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -22,11 +22,10 @@ add_filter( 'wp_page_menu_args', 'memberlite_page_menu_args' );
 /**
  * Returns the list of CPT slugs that have per-type Customizer settings.
  *
- * Auto-detects supported PMPro CPTs when registered. Use the
- * memberlite_pmpro_cpt_layout_settings_enabled filter to disable the
- * built-in PMPro CPT detection, or the memberlite_customizer_cpts filter
- * to add CPTs from a child theme or third-party plugin. Section labels are
- * derived from each post type's registered plural name.
+ * PMPro CPTs, if registered, are defaults.
+ * Use the memberlite_customizer_cpts filter to add CPTs from
+ * a child theme or third-party plugin.
+ * Section labels are derived from each post type's registered plural name.
  *
  * @since TBD
  * @return string[]
@@ -34,7 +33,7 @@ add_filter( 'wp_page_menu_args', 'memberlite_page_menu_args' );
 function memberlite_get_customizer_cpts(): array {
 	static $cache = null;
 
-	if ( null === $cache ) {
+	if ( $cache === null ) {
 		/**
 		 * Filters the CPT slugs that receive per-type layout settings in the Customizer.
 		 *
@@ -49,11 +48,9 @@ function memberlite_get_customizer_cpts(): array {
 		 * } );
 		 *
 		 * @since TBD
-		 * @param string[]|string $cpts
-		 * Indexed array of post type slugs, or a
-		 * comma-separated string of slugs. Pass an
-		 * empty array or empty string to disable all
-		 * built-in PMPro CPTs.
+		 * @param string[]|string $cpts Indexed array of post type slugs,
+		 * or a comma-separated string of slugs. Pass an empty array or
+		 * empty string to disable all built-in PMPro CPTs.
 		 */
 		$filtered = apply_filters( 'memberlite_customizer_cpts', array(
 			'pmpro_course',
@@ -68,12 +65,12 @@ function memberlite_get_customizer_cpts(): array {
 
 		// Normalize a string return to an array.
 		if ( is_string( $filtered ) ) {
-			$filtered = '' !== $filtered ? array_map( 'trim', explode( ',', $filtered ) ) : array();
+			$filtered = $filtered !== '' ? array_map( 'trim', explode( ',', $filtered ) ) : array();
 		}
 
 		// Strip non-string elements (e.g. accidental nested arrays) and empty strings.
 		$filtered = array_filter( $filtered, function( $slug ) {
-			return is_string( $slug ) && '' !== $slug;
+			return is_string( $slug ) && $slug !== '';
 		} );
 
 		// Strip Memberlite's own internal CPTs, any unregistered slugs, and any

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -22,7 +22,7 @@ add_filter( 'wp_page_menu_args', 'memberlite_page_menu_args' );
 /**
  * Returns the list of CPT slugs that have per-type Customizer settings.
  *
- * PMPro CPTs, if registered, are defaults.
+ * PMPro CPT slugs are passed as defaults; unregistered ones are filtered out before caching.
  * Use the memberlite_customizer_cpts filter to add CPTs from
  * a child theme or third-party plugin.
  * Section labels are derived from each post type's registered plural name.

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -73,12 +73,17 @@ function memberlite_get_customizer_cpts(): array {
 			return is_string( $slug ) && $slug !== '';
 		} );
 
-		// Strip Memberlite's own internal CPTs, any unregistered slugs, and any
-		// CPTs with show_ui false that may have been injected via the filter.
+		// Strip Memberlite's own internal CPTs, any unregistered slugs, any
+		// CPTs with show_ui false that may have been injected via the filter,
+		// and any duplicate slugs (which would otherwise double-register
+		// sections and double-bind the Customizer's JS visibility toggles).
 		$memberlite_internal = array( 'memberlite_header', 'memberlite_footer' );
 		$cache = array();
 
 		foreach ( array_diff( $filtered, $memberlite_internal ) as $slug ) {
+			if ( in_array( $slug, $cache, true ) ) {
+				continue;
+			}
 			$obj = get_post_type_object( $slug );
 			if ( $obj && $obj->show_ui ) {
 				$cache[] = $slug;

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -35,34 +35,6 @@ function memberlite_get_customizer_cpts(): array {
 	static $cache = null;
 
 	if ( null === $cache ) {
-		$cpts = array();
-
-		/**
-		 * Filters whether the built-in PMPro CPT layout settings are enabled.
-		 *
-		 * Return false to prevent PMPro CPTs from receiving Customizer sections.
-		 * CPTs added via the memberlite_customizer_cpts filter are unaffected.
-		 *
-		 * Example usage in a child theme:
-		 * add_filter( 'memberlite_pmpro_cpt_layout_settings_enabled', '__return_false' );
-		 *
-		 * @since TBD
-		 * @param bool $enabled Whether PMPro CPT layout settings are enabled. Default true.
-		 */
-		if ( apply_filters( 'memberlite_pmpro_cpt_layout_settings_enabled', true ) ) {
-			$pmpro_cpts = array(
-				'pmpro_course',
-				'pmpro_lesson',
-				'pmpro_series',
-			);
-
-			foreach ( $pmpro_cpts as $pmpro_cpt ) {
-				if ( post_type_exists( $pmpro_cpt ) ) {
-					$cpts[] = $pmpro_cpt;
-				}
-			}
-		}
-
 		/**
 		 * Filters the CPT slugs that receive per-type layout settings in the Customizer.
 		 *
@@ -77,17 +49,29 @@ function memberlite_get_customizer_cpts(): array {
 		 * } );
 		 *
 		 * @since TBD
-		 * @param string[] $cpts Indexed array of post type slugs.
+		 * @param string[]|string $cpts
+		 * Indexed array of post type slugs, or a
+		 * comma-separated string of slugs. Pass an
+		 * empty array or empty string to disable all
+		 * built-in PMPro CPTs.
 		 */
-		$filtered = apply_filters( 'memberlite_customizer_cpts', $cpts );
+		$filtered = apply_filters( 'memberlite_customizer_cpts', array(
+			'pmpro_course',
+			'pmpro_lesson',
+			'pmpro_series',
+		) );
 
-		// Guard against a filter callback returning a non-array; fall back to
-		// the pre-filter list so built-in PMPro CPTs are not lost.
-		if ( ! is_array( $filtered ) ) {
-			$filtered = $cpts;
+		// Coerce any unexpected return type (null, false, int, etc.) to an empty array.
+		if ( ! is_string( $filtered ) && ! is_array( $filtered ) ) {
+			$filtered = array();
 		}
 
-		// Strip any non-string or empty values injected via the filter.
+		// Normalize a string return to an array.
+		if ( is_string( $filtered ) ) {
+			$filtered = '' !== $filtered ? array_map( 'trim', explode( ',', $filtered ) ) : array();
+		}
+
+		// Strip non-string elements (e.g. accidental nested arrays) and empty strings.
 		$filtered = array_filter( $filtered, function( $slug ) {
 			return is_string( $slug ) && '' !== $slug;
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A follow up to #303 

Consolidates `memberlite_get_customizer_cpts()` from two filters down to one. The PMPro CPTs (`pmpro_course, pmpro_lesson, pmpro_series`) are now passed as the default value to `memberlite_customizer_cpts`, removing the need for the separate `memberlite_pmpro_cpt_layout_settings_enabled` (never released) filter. Adds return value guards: unexpected types coerce to `[]`, a comma-separated string is exploded into an array, and non-string or empty elements are stripped before use.

`memberlite_pmpro_cpt_layout_settings_enabled` was removed, but it was never publicly released.


### How to test the changes in this Pull Request:

  1. Confirm PMPro CPTs appear as expected in the Customizer (Courses, Lessons, Series sections present when the add-on is active).
  2. Add a filter returning a custom CPT slug and confirm it appears in the Customizer alongside the PMPro CPTs.
  3. Add a filter returning an empty array ([]) or empty string ('') and confirm all CPT Customizer sections disappear with no PHP warnings.
  4. Add a filter returning a comma-separated string (e.g. 'pmpro_course, my_cpt') and confirm both slugs are recognized.
  5. Add a filter that pushes a nested array as an element (e.g. $cpts[] = ['pmpro_series']) and confirm no "array to string conversion" warning in the debug log and the bad
  element is silently dropped.
  6. Add a filter returning null or false and confirm no warnings and an empty CPT list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Consolidates `memberlite_get_customizer_cpts()` from two filters down to one. The PMPro CPTs (`pmpro_course, pmpro_lesson, pmpro_series`) are now passed as the default value to `memberlite_customizer_cpts`, removing the need for the separate `memberlite_pmpro_cpt_layout_settings_enabled` (never released) filter. Adds return value guards: unexpected types coerce to `[]`, a comma-separated string is exploded into an array, and non-string or empty elements are stripped before use.
