### PR TITLE
Add 'inherit' checkbox above CPT layout settings

### DIFF
--- a/docs/customizer.md
+++ b/docs/customizer.md
@@ -99,11 +99,16 @@ add_filter( 'memberlite_customizer_cpts', function( $cpts ) {
 
 ### Settings per CPT
 
+Each CPT section starts with an **Inherit from Posts & Archives** checkbox (on by default). When checked, the Archive Layout, Sidebar Location, and Columns Ratio controls are hidden and the CPT uses whatever is set in Posts & Archives. Uncheck it to control the CPT independently.
+
+The inherit state is stored as the `inherit_posts_archives_{cpt}` theme_mod (e.g. `inherit_posts_archives_pmpro_course`). It defaults to `true`. This means a CPT will always fall back to Posts & Archives unless a user has explicitly unchecked the box — even if that CPT's other theme_mods have been saved.
+
 | Setting | Applies to | Shown when |
 |---|---|---|
-| Archive Layout | Archive pages only | CPT has `has_archive` |
-| Sidebar Location | Archive pages + single post views | Always |
-| Columns Ratio | Archive pages + single post views | Sidebar is not "No Sidebar" |
+| Inherit from Posts & Archives | Archive pages + single post views | Always |
+| Archive Layout | Archive pages only | Inherit is unchecked, CPT has `has_archive` |
+| Sidebar Location | Archive pages + single post views | Inherit is unchecked |
+| Columns Ratio | Archive pages + single post views | Inherit is unchecked, sidebar is not "No Sidebar" |
 
 Section labels are derived from the CPT's registered plural name (e.g. a CPT registered as "Courses" produces a "Courses Layout" section).
 
@@ -193,6 +198,8 @@ This is not a full list. Explore the codebase for more.
 ### `inc/extras.php`
 
 - `memberlite_get_customizer_cpts()` - Returns the indexed array of CPT slugs that receive per-type layout settings. PMPro CPTs are passed as defaults to the `memberlite_customizer_cpts` filter. After the filter, normalizes the return value (string → array, unexpected types → empty array), then strips internal Memberlite CPTs, unregistered slugs, CPTs with `show_ui => false`, and any non-string or empty elements. Result is statically cached.
+
+- `memberlite_cpt_inherits_posts_archives( $cpt_type )` - Returns `true` if the given CPT should inherit layout settings from Posts & Archives. Reads the `inherit_posts_archives_{cpt}` theme_mod; defaults to `true` so CPTs inherit unless explicitly opted out.
 
 - `memberlite_get_current_cpt_type()` - Returns the current CPT slug when on a CPT archive or single post that has Customizer settings, otherwise `null`. Used to resolve sidebar and columns ratio settings for both archive and single views.
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -653,7 +653,7 @@ class Memberlite_Customize {
 				$section  = 'memberlite_' . $post_type . '_archive_options';
 				$post_type_obj = get_post_type_object( $post_type );
 
-				// CPT: Inherit from Posts & Archives ==
+				// Inherit from Posts & Archives ==
 				self::add_memberlite_setting_control( $wp_customize, 'inherit_posts_archives_' . $post_type, __( 'Inherit from Posts & Archives', 'memberlite' ), $section, array(
 					'type'              => 'checkbox',
 					'default'           => true,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -653,6 +653,14 @@ class Memberlite_Customize {
 				$section  = 'memberlite_' . $post_type . '_archive_options';
 				$post_type_obj = get_post_type_object( $post_type );
 
+				// CPT: Inherit from Posts & Archives ==
+				self::add_memberlite_setting_control( $wp_customize, 'inherit_posts_archives_' . $post_type, __( 'Inherit from Posts & Archives', 'memberlite' ), $section, array(
+					'type'              => 'checkbox',
+					'default'           => true,
+					'description'       => __( 'When checked, this post type uses the layout settings from Posts & Archives. Uncheck to control it separately.', 'memberlite' ),
+					'sanitize_callback' => array( 'Memberlite_Customize', 'sanitize_checkbox' ),
+				) );
+
 				if ( $post_type_obj && $post_type_obj->has_archive ) {
 					self::add_memberlite_setting_control( $wp_customize, 'content_archives_' . $post_type, __( 'Archive Layout', 'memberlite' ), $section, array(
 						'type'        => 'radio',
@@ -663,6 +671,9 @@ class Memberlite_Customize {
 							'excerpt' => __( 'Show Post Excerpts', 'memberlite' ),
 							'grid'    => __( 'Show Posts in a Grid (sidebar hidden)', 'memberlite' ),
 						),
+						'active_callback' => function() use ( $post_type ) {
+							return ! (bool) get_theme_mod( 'inherit_posts_archives_' . $post_type, true );
+						},
 					) );
 				}
 
@@ -679,6 +690,9 @@ class Memberlite_Customize {
 						'sidebar-blog-left'  => __( 'Left Sidebar', 'memberlite' ),
 						'sidebar-blog-none'  => __( 'No Sidebar', 'memberlite' ),
 					),
+					'active_callback' => function() use ( $post_type ) {
+						return ! (bool) get_theme_mod( 'inherit_posts_archives_' . $post_type, true );
+					},
 				) );
 
 				self::add_memberlite_setting_control( $wp_customize, 'columns_ratio_' . $post_type, __( 'Columns Ratio', 'memberlite' ), $section, array(
@@ -695,7 +709,8 @@ class Memberlite_Customize {
 						'11-1' => '11x1',
 					),
 					'active_callback' => function() use ( $post_type ) {
-						return get_theme_mod( 'sidebar_location_' . $post_type, 'sidebar-blog-right' ) !== 'sidebar-blog-none';
+						return ! (bool) get_theme_mod( 'inherit_posts_archives_' . $post_type, true )
+							&& get_theme_mod( 'sidebar_location_' . $post_type, 'sidebar-blog-right' ) !== 'sidebar-blog-none';
 					},
 				) );
 			}

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -119,6 +119,17 @@ function memberlite_get_current_cpt_archive_type(): ?string {
 }
 
 /**
+ * Returns true if the given CPT should inherit layout settings from Posts & Archives.
+ *
+ * @since TBD
+ * @param string $cpt_type CPT slug.
+ * @return bool
+ */
+function memberlite_cpt_inherits_posts_archives( string $cpt_type ): bool {
+	return (bool) get_theme_mod( 'inherit_posts_archives_' . $cpt_type, true );
+}
+
+/**
  * Returns the current CPT slug if we are on a CPT archive or single post
  * that has Customizer settings, otherwise null.
  *
@@ -159,6 +170,9 @@ function memberlite_get_content_archives_theme_mod(): string {
 	$cpt_type = memberlite_get_current_cpt_archive_type();
 
 	if ( $cpt_type ) {
+		if ( memberlite_cpt_inherits_posts_archives( $cpt_type ) ) {
+			return get_theme_mod( 'content_archives', $memberlite_defaults['content_archives'] );
+		}
 		return get_theme_mod( 'content_archives_' . $cpt_type, 'content' );
 	}
 
@@ -178,7 +192,11 @@ function memberlite_body_classes( $classes ) {
 	if ( ! is_page_template( 'templates/fluid-width.php' ) && ! memberlite_is_blog() && ! is_post_type_archive() ) {
 		$cpt_type = is_singular() ? memberlite_get_current_cpt_type() : null;
 		if ( $cpt_type ) {
-			$classes[] = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			if ( memberlite_cpt_inherits_posts_archives( $cpt_type ) ) {
+				$classes[] = get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] );
+			} else {
+				$classes[] = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			}
 		} else {
 			$classes[] = get_theme_mod( 'sidebar_location', $memberlite_defaults['sidebar_location'] );
 		}
@@ -192,8 +210,13 @@ function memberlite_body_classes( $classes ) {
 	if ( is_post_type_archive() ) {
 		$cpt_type = memberlite_get_current_cpt_archive_type();
 		if ( $cpt_type ) {
-			$classes[] = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
-			$classes[] = 'content-archives-' . get_theme_mod( 'content_archives_' . $cpt_type, 'content' );
+			if ( memberlite_cpt_inherits_posts_archives( $cpt_type ) ) {
+				$classes[] = get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] );
+				$classes[] = 'content-archives-' . get_theme_mod( 'content_archives', $memberlite_defaults['content_archives'] );
+			} else {
+				$classes[] = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+				$classes[] = 'content-archives-' . get_theme_mod( 'content_archives_' . $cpt_type, 'content' );
+			}
 		} else {
 			$classes[] = get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] );
 			$classes[] = 'content-archives-' . get_theme_mod( 'content_archives', $memberlite_defaults['content_archives'] );
@@ -249,7 +272,11 @@ function memberlite_getColumnsRatio( $location = null ) {
 		$cpt_type = memberlite_get_current_cpt_type();
 
 		if ( $cpt_type ) {
-			$columns_ratio = get_theme_mod( 'columns_ratio_' . $cpt_type, '8-4' );
+			if ( memberlite_cpt_inherits_posts_archives( $cpt_type ) ) {
+				$columns_ratio = get_theme_mod( 'columns_ratio_blog', $columns_ratio );
+			} else {
+				$columns_ratio = get_theme_mod( 'columns_ratio_' . $cpt_type, '8-4' );
+			}
 		} else {
 			$columns_ratio = get_theme_mod( 'columns_ratio_blog', $columns_ratio );
 		}
@@ -303,7 +330,9 @@ function memberlite_sidebar_location_none_columns_ratio( $r, $location ) {
 		$content_archives = memberlite_get_content_archives_theme_mod();
 
 		if ( $cpt_type ) {
-			$sidebar_location = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			$sidebar_location = memberlite_cpt_inherits_posts_archives( $cpt_type )
+				? get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] )
+				: get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
 		} else {
 			$sidebar_location = get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] );
 		}
@@ -317,7 +346,9 @@ function memberlite_sidebar_location_none_columns_ratio( $r, $location ) {
 		$cpt_type = memberlite_get_current_cpt_type();
 
 		if ( $cpt_type ) {
-			$sidebar_location = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			$sidebar_location = memberlite_cpt_inherits_posts_archives( $cpt_type )
+				? get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] )
+				: get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
 			if ( $sidebar_location === 'sidebar-blog-none' ) {
 				$r = '8 medium-offset-2';
 			}
@@ -346,7 +377,9 @@ function memberlite_sidebar_none_get_sidebar( $name ) {
 		$content_archives = memberlite_get_content_archives_theme_mod();
 
 		if ( $cpt_type ) {
-			$sidebar_location = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			$sidebar_location = memberlite_cpt_inherits_posts_archives( $cpt_type )
+				? get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] )
+				: get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
 		} else {
 			$sidebar_location = get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] );
 		}
@@ -361,9 +394,11 @@ function memberlite_sidebar_none_get_sidebar( $name ) {
 		}
 	} elseif ( is_singular() ) {
 		$cpt_type = memberlite_get_current_cpt_type();
-		
+
 		if ( $cpt_type ) {
-			$sidebar_location = get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
+			$sidebar_location = memberlite_cpt_inherits_posts_archives( $cpt_type )
+				? get_theme_mod( 'sidebar_location_blog', $memberlite_defaults['sidebar_location_blog'] )
+				: get_theme_mod( 'sidebar_location_' . $cpt_type, 'sidebar-blog-right' );
 			if ( $sidebar_location === 'sidebar-blog-none' ) {
 				$name = false;
 			}

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -126,6 +126,9 @@ function memberlite_get_current_cpt_archive_type(): ?string {
  * @return bool
  */
 function memberlite_cpt_inherits_posts_archives( string $cpt_type ): bool {
+	if ( ! in_array( $cpt_type, memberlite_get_customizer_cpts(), true ) ) {
+		return true;
+	}
 	return (bool) get_theme_mod( 'inherit_posts_archives_' . $cpt_type, true );
 }
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -120,6 +120,7 @@ function memberlite_get_current_cpt_archive_type(): ?string {
 
 /**
  * Returns true if the given CPT should inherit layout settings from Posts & Archives.
+ * Also returns true if the CPT is no longer being passed through the memberlite_customizer_cpts filter.
  *
  * @since TBD
  * @param string $cpt_type CPT slug.

--- a/js/customizer-controls.js
+++ b/js/customizer-controls.js
@@ -192,17 +192,37 @@
 		});
 	});
 
-	// Toggle columns_ratio visibility for CPTs based on sidebar_location value.
+	// Toggle CPT controls based on inherit checkbox and sidebar_location value.
 	if ( typeof memberlite_cpt_archive_slugs !== 'undefined' ) {
 		memberlite_cpt_archive_slugs.forEach( function( postType ) {
+			const inheritKey = 'inherit_posts_archives_' + postType;
+			const archiveKey = 'content_archives_' + postType;
 			const sidebarKey = 'sidebar_location_' + postType;
 			const ratioKey   = 'columns_ratio_' + postType;
 
+			function updateRatioVisibility( inherited, sidebarVal ) {
+				wp.customize.control( ratioKey, function( control ) {
+					control.active.set( ! inherited && sidebarVal !== 'sidebar-blog-none' );
+				} );
+			}
+
+			wp.customize( inheritKey, function( setting ) {
+				setting.bind( function( inherited ) {
+					wp.customize.control( archiveKey, function( control ) {
+						control.active.set( ! inherited );
+					} );
+					wp.customize.control( sidebarKey, function( control ) {
+						control.active.set( ! inherited );
+					} );
+					const sidebarVal = wp.customize( sidebarKey ) ? wp.customize( sidebarKey )() : 'sidebar-blog-right';
+					updateRatioVisibility( inherited, sidebarVal );
+				} );
+			} );
+
 			wp.customize( sidebarKey, function( value ) {
 				value.bind( function( newval ) {
-					wp.customize.control( ratioKey, function( control ) {
-						control.active.set( newval !== 'sidebar-blog-none' );
-					} );
+					const inherited = wp.customize( inheritKey ) ? wp.customize( inheritKey )() : true;
+					updateRatioVisibility( inherited, newval );
 				} );
 			} );
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Inherit from Posts & Archives**

Each CPT section in the Customizer now opens with an **Inherit** from **Posts & Archives** checkbox, checked by default. When checked, the **Archive Layout, Sidebar Location, and Columns Ratio** controls are hidden and the CPT uses the **Posts & Archives** values everywhere (archives, single posts, sidebar visibility, columns ratio). Unchecking reveals the CPT-specific controls. The setting is stored as inherit_posts_archives_{cpt} and defaults to true, so CPTs always fall back to **Posts & Archives** unless a user has explicitly  opted out — even if CPT-specific `theme_mods` were previously saved.

If for some reason the CPT is still being used in WordPress, but it's no longer being passed through the `memberlite_customizer_cpts` filter, therefore removing those Customizer settings, it will fall back to the settings in **Posts & Archives.**


### How to test the changes in this Pull Request:

 1. Activate a PMPro add-on that registers a supported CPT (e.g. PMPro Courses). (Or you can check with your own CPT)
 2. Open Appearance > Customize > **Other Post Types** and expand the CPT section.
 3. Confirm the inherit checkbox is checked and **Archive Layout / Sidebar Location / Columns Ratio** are hidden.
 4. Change a **Posts & Archives** setting (e.g. switch to Left Sidebar) and confirm the CPT archive and single post previews update to match.
 5. Uncheck the inherit box — confirm the three CPT controls appear with their own defaults.
 6. Set a CPT-specific sidebar value, save, and confirm it applies on the CPT archive and a single post of that type.
 7. Re-check inherit and confirm the CPT reverts to the **Posts & Archives** value in the preview.
 8. Test the filter: Add the snippet below to a child theme and confirm the **Other Post Types** panel disappears from the Customizer.

`add_filter( 'memberlite_customizer_cpts', function( $cpts ) {
	$cpts = [];
	return $cpts;
} );`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Each CPT section in the Customizer now opens with an Inherit from Posts & Archives checkbox, checked by default. When checked, the Archive Layout, Sidebar Location, and Columns Ratio controls are hidden and the CPT uses the Posts & Archives values everywhere (archives, single posts, sidebar visibility, columns ratio). Unchecking reveals the CPT-specific controls. The setting is stored as inherit_posts_archives_{cpt} and defaults to true, so CPTs always fall back to Posts & Archives unless a user has explicitly opted out — even if CPT-specific theme_mods were previously saved..
