### PR TITLE
Properly deprecate banner hooks from 6.1.1

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -589,32 +589,3 @@ function memberlite_get_variation( $slug ) {
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
 	return 'default';
 }
-
-/**
- * Deprecated: 'memberlite_get_banner_image' filter.
- *
- * Previously applied in memberlite_get_banner_image() (formerly in inc/extras.php) to allow
- * filtering the banner image HTML output. The function was refactored in 7.0 and moved to
- * inc/page_banners.php with a revised signature ($post_id as the first argument instead of
- * $attachment_id); this filter was not carried over.
- *
- * @deprecated 7.0 No replacement.
- *
- * Old filter: add_filter( 'memberlite_get_banner_image', 'callback', 10, 6 );
- * Old params: string $html, int $attachment_id, string $size, bool $icon, string $attr, int $post_id
- */
-
-/**
- * Deprecated: 'memberlite_banner_image_src' filter.
- *
- * Previously applied in memberlite_get_banner_image_src() (formerly in inc/extras.php) to allow
- * filtering the banner image source array returned by wp_get_attachment_image_src(). The function
- * was refactored in 7.0 and moved to inc/page_banners.php with revised logic that looks up the
- * dedicated banner image from MemberliteMultiPostThumbnails directly; this filter was not
- * carried over.
- *
- * @deprecated 7.0 No replacement.
- *
- * Old filter: add_filter( 'memberlite_banner_image_src', 'callback', 10, 3 );
- * Old params: array $src, string $size, int $post_id
- */

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -573,6 +573,34 @@ function memberlite_get_legacy_color_scheme_definitions(): array {
 }
 
 /**
+ * Get the post thumbnail image HTML and allow filtering.
+ *
+ * @since 6.1.1
+ * @deprecated 7.0 No replacement available.
+ *
+ * @return string Empty string.
+ */
+function memberlite_get_banner_image() {
+	_deprecated_function( __FUNCTION__, '7.0' );
+
+	return '';
+}
+
+/**
+ * Get the post thumbnail image src and allow filtering.
+ *
+ * @since 6.1.1
+ * @deprecated 7.0 No replacement available.
+ *
+ * @return false
+ */
+function memberlite_get_banner_image_src() {
+	_deprecated_function( __FUNCTION__, '7.0' );
+
+	return false;
+}
+
+/**
  * Helper function meant to fetch template parts based on variation.
  * $slug kept for backwards compatibility.
  * Always returns 'default'.

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -42,6 +42,8 @@ $memberlite_map_deprecated_hooks = array(
 	'memberlite_before_site_info'       => 'before_site_info',
 	'memberlite_after_site_info'        => 'after_site_info',
 	'memberlite_editor_color_palette'	=> null,
+	'memberlite_get_banner_image'       => null,
+	'memberlite_banner_image_src'       => null,
 );
 
 foreach ( $memberlite_map_deprecated_hooks as $new => $old ) {
@@ -587,3 +589,32 @@ function memberlite_get_variation( $slug ) {
 	// No replacement for this function, returning 'default' will get the components/footer/variation-default.php template part
 	return 'default';
 }
+
+/**
+ * Deprecated: 'memberlite_get_banner_image' filter.
+ *
+ * Previously applied in memberlite_get_banner_image() (formerly in inc/extras.php) to allow
+ * filtering the banner image HTML output. The function was refactored in 7.0 and moved to
+ * inc/page_banners.php with a revised signature ($post_id as the first argument instead of
+ * $attachment_id); this filter was not carried over.
+ *
+ * @deprecated 7.0 No replacement.
+ *
+ * Old filter: add_filter( 'memberlite_get_banner_image', 'callback', 10, 6 );
+ * Old params: string $html, int $attachment_id, string $size, bool $icon, string $attr, int $post_id
+ */
+
+/**
+ * Deprecated: 'memberlite_banner_image_src' filter.
+ *
+ * Previously applied in memberlite_get_banner_image_src() (formerly in inc/extras.php) to allow
+ * filtering the banner image source array returned by wp_get_attachment_image_src(). The function
+ * was refactored in 7.0 and moved to inc/page_banners.php with revised logic that looks up the
+ * dedicated banner image from MemberliteMultiPostThumbnails directly; this filter was not
+ * carried over.
+ *
+ * @deprecated 7.0 No replacement.
+ *
+ * Old filter: add_filter( 'memberlite_banner_image_src', 'callback', 10, 3 );
+ * Old params: array $src, string $size, int $post_id
+ */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Something I discovered when updated the Memberlite docs and reviewing our [Action](https://www.paidmembershipspro.com/documentation/memberlite/)/[Filter](https://www.paidmembershipspro.com/documentation/memberlite/filter-hook/) hooks pages. The `memberlite_get_banner_image` and `memberlite_banner_image_src` hooks are deprecated and removed from the docs, but we never properly marked them as deprecated in the theme for our 7.0 release. You can see where these hooks were used in [version 6.1.1](https://github.com/strangerstudios/memberlite/blob/74409cf75f956a17f34f6873f972ecda6fc8bd07/inc/extras.php#L903).

### How to test the changes in this Pull Request:

N/A

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added the `memberlite_get_banner_image` and `memberlite_banner_image_src` hooks to `deprecated.php`. They were deprecated in Memberlite 7.0.
