### PR TITLE
Escape the memberlite_btn text attribute for security

### DIFF
--- a/shortcodes/buttons.php
+++ b/shortcodes/buttons.php
@@ -41,7 +41,7 @@ function memberlite_btn_shortcode($atts, $content = null) {
 	if( !empty( $icon ) && ( empty($icon_position) || ($icon_position == 'before') ) ) {
 		$r .= '<i class="' . esc_attr( $icon_class ) . ' fa-' . esc_attr( $icon ) . '"></i>';
 	}
-	$r .= $text;
+	$r .= wp_kses_post( $text );
 	if( !empty( $icon ) && ( $icon_position == 'after' ) ) {
 		$r .= '<i class="' . esc_attr( $icon_class ) . ' fa-' . esc_attr( $icon ) . '"></i>';
 	}

--- a/shortcodes/buttons.php
+++ b/shortcodes/buttons.php
@@ -41,7 +41,7 @@ function memberlite_btn_shortcode($atts, $content = null) {
 	if( !empty( $icon ) && ( empty($icon_position) || ($icon_position == 'before') ) ) {
 		$r .= '<i class="' . esc_attr( $icon_class ) . ' fa-' . esc_attr( $icon ) . '"></i>';
 	}
-	$r .= wp_kses_post( $text );
+	$r .= esc_html( $text );
 	if( !empty( $icon ) && ( $icon_position == 'after' ) ) {
 		$r .= '<i class="' . esc_attr( $icon_class ) . ' fa-' . esc_attr( $icon ) . '"></i>';
 	}


### PR DESCRIPTION
## Summary

Escapes the `text` attribute of the `[memberlite_btn]` shortcode before it is output, replacing a raw concatenation with `esc_html()`:

```php
- $r .= $text;
+ $r .= esc_html( $text );
```

This was the last raw, Contributor-injectable output left in the Memberlite shortcodes. The `text` attribute was concatenated directly into the button markup, so a user able to add shortcodes (e.g. a Contributor) could inject `<script>` or event-handler attributes that would execute when the button rendered — a stored XSS gap.

`esc_html()` strips HTML from the text and just renders the characters.

## Related prior fixes

This closes the one gap the earlier Patchstack-reported shortcode fixes did not touch:

- #51 — accordion shortcode escaping
- #52 — row / column shortcode escaping
- CVE-2025-48087 — the associated cross-site scripting advisory for the Memberlite shortcodes

## Testing

- Confirmed a `text` value containing `<script>` or any other HTML is stripped.
