### PR TITLE
Align CPT archive content and sidebar - new post archive stylesheet

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -30,9 +30,10 @@
 	4.3 Footer (_footer.scss)
 	4.4 Content (_content.scss)
 5.0 Pages
-	5.1 Blog (_blog.scss)
-	5.2 404 (_404.scss)
-	5.3 Page (_page.scss)
+	5.1 Archives (_archives.scss)
+	5.2 Blog (_blog.scss)
+	5.3 404 (_404.scss)
+	5.4 Page (_page.scss)
 6.0 Plugins
 	6.1 Paid Memberships Pro (_pmpro.scss)
 	6.2 bbPress (_bbpress.scss)
@@ -76,6 +77,7 @@
 /*--------------------------------------------------------------
  PAGES
 --------------------------------------------------------------*/
+@use "pages/archive";
 @use "pages/blog";
 @use "pages/no-results-404";
 @use "pages/page";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -30,9 +30,9 @@
 	4.3 Footer (_footer.scss)
 	4.4 Content (_content.scss)
 5.0 Pages
-	5.1 Archives (_archives.scss)
+	5.1 Archives (_archive.scss)
 	5.2 Blog (_blog.scss)
-	5.3 404 (_404.scss)
+	5.3 404 (_no-results-404.scss)
 	5.4 Page (_page.scss)
 6.0 Plugins
 	6.1 Paid Memberships Pro (_pmpro.scss)

--- a/src/scss/pages/_archive.scss
+++ b/src/scss/pages/_archive.scss
@@ -1,0 +1,9 @@
+/*--------------------------------------------------------------
+ 5.1 Non-Blog related archives
+--------------------------------------------------------------*/
+
+.post-type-archive #primary {
+	 article:first-of-type .entry-title {
+			 margin-top: 0;
+	 }
+}

--- a/src/scss/pages/_archive.scss
+++ b/src/scss/pages/_archive.scss
@@ -4,6 +4,6 @@
 
 .post-type-archive #primary {
 	 article:first-of-type .entry-title {
-			 margin-top: 0;
+		 margin-top: 0;
 	 }
 }

--- a/src/scss/pages/_blog.scss
+++ b/src/scss/pages/_blog.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.1 Pages: Blog and Single Post
+ 5.2 Pages: Blog and Single Post
 
  Covers: Blog layout, single post layout, sidebar ordering, wide/full alignments
 --------------------------------------------------------------*/

--- a/src/scss/pages/_no-results-404.scss
+++ b/src/scss/pages/_no-results-404.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.2 Pages: 404 and No Search Results
+ 5.3 Pages: 404 and No Search Results
 
  Covers: 404 error page, search-no-results layout, search form styling
 --------------------------------------------------------------*/

--- a/src/scss/pages/_page.scss
+++ b/src/scss/pages/_page.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.3 Pages: Pages and Templates
+ 5.4 Pages: Pages and Templates
 
  Covers: Page layout, template ordering, wide/full alignments
 --------------------------------------------------------------*/


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removes the margin top on the _first_ post's title on post type archives. I noticed that the content and the sidebar are horizontally aligned on the blog but it wasn't for CPT archives. I've added a new stylesheet as a result for non-blog related archive styles.

📓 The blog and category/taxonomy/date archives will be unaffected by these styles. This CSS should only affect post type archives that aren't for `post`. This has been tested both when the homepage is set to show the latest posts, and when you set a separate page (e.g. Blog) as a page to show your posts. These archives have different styles applying to them.

bbPress is also unaffected because it's not using the same classes as an archive with posts on it.

**Before:**
<img width="1864" height="583" alt="image" src="https://github.com/user-attachments/assets/13cafc6a-8d18-4f14-a512-509be200a8cd" />

**After:**
<img width="1835" height="549" alt="image" src="https://github.com/user-attachments/assets/e9f482b9-096b-428b-9d2b-a949ad996b82" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added a new `_archives.scss` stylesheet for non-blog related styling. Adjusted margin for CPT archives so content and sidebars are horizontally aligned.
