### PR TITLE
Make `.entry-title` a global style

### DIFF
--- a/src/scss/components/_shortcodes.scss
+++ b/src/scss/components/_shortcodes.scss
@@ -288,10 +288,6 @@ details {
 
 	.post.hentry {
 		margin-bottom: 0;
-
-		.entry-header .entry-title {
-			margin: 0;
-		}
 	}
 
 	// With thumbnail — grid layout

--- a/src/scss/components/_widgets.scss
+++ b/src/scss/components/_widgets.scss
@@ -210,7 +210,6 @@
 	.entry-title {
 		align-self: end;
 		grid-area: title;
-		margin: 0;
 	}
 
 	.post-date {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -30,10 +30,9 @@
 	4.3 Footer (_footer.scss)
 	4.4 Content (_content.scss)
 5.0 Pages
-	5.1 Archives (_archive.scss)
-	5.2 Blog (_blog.scss)
-	5.3 404 (_no-results-404.scss)
-	5.4 Page (_page.scss)
+	5.1 Blog (_blog.scss)
+	5.2 404 (_no-results-404.scss)
+	5.3 Page (_page.scss)
 6.0 Plugins
 	6.1 Paid Memberships Pro (_pmpro.scss)
 	6.2 bbPress (_bbpress.scss)
@@ -77,7 +76,6 @@
 /*--------------------------------------------------------------
  PAGES
 --------------------------------------------------------------*/
-@use "pages/archive";
 @use "pages/blog";
 @use "pages/no-results-404";
 @use "pages/page";

--- a/src/scss/pages/_archive.scss
+++ b/src/scss/pages/_archive.scss
@@ -1,9 +1,0 @@
-/*--------------------------------------------------------------
- 5.1 Non-Blog related archives
---------------------------------------------------------------*/
-
-.post-type-archive #primary {
-	 article:first-of-type .entry-title {
-		 margin-top: 0;
-	 }
-}

--- a/src/scss/pages/_blog.scss
+++ b/src/scss/pages/_blog.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.2 Pages: Blog and Single Post
+ 5.1 Pages: Blog and Single Post
 
  Covers: Blog layout, single post layout, sidebar ordering, wide/full alignments
 --------------------------------------------------------------*/

--- a/src/scss/pages/_no-results-404.scss
+++ b/src/scss/pages/_no-results-404.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.3 Pages: 404 and No Search Results
+ 5.2 Pages: 404 and No Search Results
 
  Covers: 404 error page, search-no-results layout, search form styling
 --------------------------------------------------------------*/

--- a/src/scss/pages/_page.scss
+++ b/src/scss/pages/_page.scss
@@ -2,7 +2,7 @@
 @use "../abstracts/mixins" as *;
 
 /*--------------------------------------------------------------
- 5.4 Pages: Pages and Templates
+ 5.3 Pages: Pages and Templates
 
  Covers: Page layout, template ordering, wide/full alignments
 --------------------------------------------------------------*/

--- a/src/scss/structure/_content.scss
+++ b/src/scss/structure/_content.scss
@@ -74,7 +74,6 @@
 		margin: 0 0 var(--wp--preset--spacing--10) 0;
 
 		.entry-title {
-			margin: 0;
 			hyphens: auto;
 		}
 
@@ -104,6 +103,7 @@
 .entry-title {
 	overflow-wrap: break-word;
 	word-break: break-word;
+	margin: 0;
 }
 
 


### PR DESCRIPTION
An alternate approach to PR https://github.com/strangerstudios/memberlite/pull/323.

The original solution targeted post type archives on two column layouts, to ensure the content and the sidebar were both horizontally aligned (without margin interfering).

The new style change now removes margin from all `.entry-title` instances. I've regression tested the blog/post archive, pages, a CPT archive, single view for post/CPT -- desktop and mobile. Checked the layout with the sidebar on the left, sidebar on the right, no sidebar and grid view for archives. Post and CPTs still look good. 👍 Any redundant styles have been removed.