### PR TITLE
On Hold: Enable gradients in the theme.json, added dynamic gradient color palette

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -720,6 +720,72 @@ function memberlite_theme_mod_copyright_textbox( $copyright_text ) {
 add_filter( 'theme_mod_copyright_textbox', 'memberlite_theme_mod_copyright_textbox' );
 
 /**
+ * Build the gradient palette array from active color scheme colors.
+ *
+ * Returns an empty array if any of the three required colors (button, secondary, action)
+ * are missing from $active_colors, so the caller can skip gradient registration safely.
+ *
+ * @since TBD
+ *
+ * @param array $active_colors Sanitized active colors keyed by setting name, each prefixed with '#'.
+ * @return array Gradient definition arrays, or empty array if required colors are absent.
+ */
+function memberlite_build_gradient_palette( array $active_colors ): array {
+	if ( ! isset( $active_colors['color_button'], $active_colors['color_secondary'], $active_colors['color_action'] ) ) {
+		return array();
+	}
+
+	$btn  = $active_colors['color_button'];
+	$sec  = $active_colors['color_secondary'];
+	$acc  = $active_colors['color_action'];
+
+	$btn_dark  = memberlite_adjust_color_brightness( $btn, -40 );
+	$btn_light = memberlite_adjust_color_brightness( $btn, 40 );
+	$sec_dark  = memberlite_adjust_color_brightness( $sec, -30 );
+	$sec_light = memberlite_adjust_color_brightness( $sec, 30 );
+	$acc_dark  = memberlite_adjust_color_brightness( $acc, -50 );
+	$acc_light = memberlite_adjust_color_brightness( $acc, 50 );
+
+	return array(
+		array(
+			'slug'     => 'secondary-to-dark',
+			'name'     => __( 'Secondary to Dark', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$sec} 0%, {$sec_dark} 100%)",
+		),
+		array(
+			'slug'     => 'secondary-to-light',
+			'name'     => __( 'Secondary to Light', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$sec} 0%, {$sec_light} 100%)",
+		),
+		array(
+			'slug'     => 'secondary-to-accent',
+			'name'     => __( 'Secondary to Accent', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$sec_dark} 0%, {$acc_dark} 100%)",
+		),
+		array(
+			'slug'     => 'accent-to-dark',
+			'name'     => __( 'Accent to Dark', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$acc} 0%, {$acc_dark} 100%)",
+		),
+		array(
+			'slug'     => 'accent-to-light',
+			'name'     => __( 'Accent to Light', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$acc} 0%, {$acc_light} 100%)",
+		),
+		array(
+			'slug'     => 'button-to-dark',
+			'name'     => __( 'Button to Dark', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$btn} 0%, {$btn_dark} 100%)",
+		),
+		array(
+			'slug'     => 'button-to-light',
+			'name'     => __( 'Button to Light', 'memberlite' ),
+			'gradient' => "linear-gradient(90deg, {$btn} 0%, {$btn_light} 100%)",
+		),
+	);
+}
+
+/**
  * Filter theme.json data to add theme settings
  *
  * @since 7.0
@@ -796,6 +862,13 @@ function memberlite_filter_theme_json( $theme_json ) {
 	}
 
 	$theme_json_data['settings']['color']['palette'] = $color_palette;
+
+	// Build gradient palette from active customizer colors.
+	$gradient_palette = memberlite_build_gradient_palette( $active_colors );
+	if ( ! empty( $gradient_palette ) ) {
+		$theme_json_data['settings']['color']['gradients'] = $gradient_palette;
+	}
+	$theme_json_data['settings']['color']['defaultGradients'] = false;
 
 	// Add font family custom properties.
 	if ( ! isset( $theme_json_data['settings']['custom'] ) ) {

--- a/functions.php
+++ b/functions.php
@@ -759,7 +759,7 @@ function memberlite_build_gradient_palette( array $active_colors ): array {
 		),
 		array(
 			'slug'     => 'secondary-to-accent',
-			'name'     => __( 'Secondary to Accent', 'memberlite' ),
+			'name'     => __( 'Secondary Dark to Accent Dark', 'memberlite' ),
 			'gradient' => "linear-gradient(90deg, {$sec_dark} 0%, {$acc_dark} 100%)",
 		),
 		array(
@@ -867,8 +867,8 @@ function memberlite_filter_theme_json( $theme_json ) {
 	$gradient_palette = memberlite_build_gradient_palette( $active_colors );
 	if ( ! empty( $gradient_palette ) ) {
 		$theme_json_data['settings']['color']['gradients'] = $gradient_palette;
+		$theme_json_data['settings']['color']['defaultGradients'] = false;
 	}
-	$theme_json_data['settings']['color']['defaultGradients'] = false;
 
 	// Add font family custom properties.
 	if ( ! isset( $theme_json_data['settings']['custom'] ) ) {

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -146,6 +146,85 @@
 	} );
 
 	/**
+	 * Adjust a hex color's brightness by a percent (-100 to 100).
+	 *
+	 * Mirrors memberlite_adjust_color_brightness() in inc/colors.php so the
+	 * live preview computes the exact same dark/light variants PHP bakes
+	 * into the gradient presets on page load.
+	 */
+	function adjustColorBrightness( hexColor, percent ) {
+		var hex = hexColor.replace( /^#/, '' );
+		if ( hex.length === 3 ) {
+			hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+		}
+
+		var r = parseInt( hex.substr( 0, 2 ), 16 );
+		var g = parseInt( hex.substr( 2, 2 ), 16 );
+		var b = parseInt( hex.substr( 4, 2 ), 16 );
+
+		r = Math.max( 0, Math.min( 255, r + ( r * percent / 100 ) ) );
+		g = Math.max( 0, Math.min( 255, g + ( g * percent / 100 ) ) );
+		b = Math.max( 0, Math.min( 255, b + ( b * percent / 100 ) ) );
+
+		function toHex( channel ) {
+			return ( '0' + Math.round( channel ).toString( 16 ) ).slice( -2 );
+		}
+
+		return '#' + toHex( r ) + toHex( g ) + toHex( b );
+	}
+
+	/**
+	 * Build the same 7 gradient definitions as memberlite_build_gradient_palette()
+	 * in functions.php, using the button/secondary/action colors.
+	 */
+	function buildGradientPalette( btn, sec, acc ) {
+		var btnDark  = adjustColorBrightness( btn, -40 );
+		var btnLight = adjustColorBrightness( btn, 40 );
+		var secDark  = adjustColorBrightness( sec, -30 );
+		var secLight = adjustColorBrightness( sec, 30 );
+		var accDark  = adjustColorBrightness( acc, -50 );
+		var accLight = adjustColorBrightness( acc, 50 );
+
+		return [
+			{ slug: 'secondary-to-dark', gradient: 'linear-gradient(90deg, ' + sec + ' 0%, ' + secDark + ' 100%)' },
+			{ slug: 'secondary-to-light', gradient: 'linear-gradient(90deg, ' + sec + ' 0%, ' + secLight + ' 100%)' },
+			{ slug: 'secondary-to-accent', gradient: 'linear-gradient(90deg, ' + secDark + ' 0%, ' + accDark + ' 100%)' },
+			{ slug: 'accent-to-dark', gradient: 'linear-gradient(90deg, ' + acc + ' 0%, ' + accDark + ' 100%)' },
+			{ slug: 'accent-to-light', gradient: 'linear-gradient(90deg, ' + acc + ' 0%, ' + accLight + ' 100%)' },
+			{ slug: 'button-to-dark', gradient: 'linear-gradient(90deg, ' + btn + ' 0%, ' + btnDark + ' 100%)' },
+			{ slug: 'button-to-light', gradient: 'linear-gradient(90deg, ' + btn + ' 0%, ' + btnLight + ' 100%)' }
+		];
+	}
+
+	/**
+	 * Recompute and rewrite all 7 gradient preset vars whenever the button,
+	 * secondary, or action color changes. These vars live in the same
+	 * global-styles-inline-css tag WordPress core writes color/gradient
+	 * presets into, so has-{slug}-gradient-background classes (which
+	 * reference var(--wp--preset--gradient--{slug})) pick up the change
+	 * immediately without a preview reload.
+	 */
+	function updateGradientPalette() {
+		var btn = normalizeColorValue( wp.customize( 'color_button' )() );
+		var sec = normalizeColorValue( wp.customize( 'color_secondary' )() );
+		var acc = normalizeColorValue( wp.customize( 'color_action' )() );
+
+		if ( ! btn || ! sec || ! acc ) {
+			return;
+		}
+
+		buildGradientPalette( btn, sec, acc ).forEach( function( entry ) {
+			updateCssVarInStyleTag( 'global-styles-inline-css', '--wp--preset--gradient--' + entry.slug, entry.gradient );
+		} );
+	}
+
+	[ 'color_button', 'color_secondary', 'color_action' ].forEach( function( settingId ) {
+		wp.customize( settingId, function( setting ) {
+			setting.bind( updateGradientPalette );
+		} );
+	} );
+
+	/**
 	 * When background_color changes, toggle is-style-dark / is-style-light
 	 * body class and update the color-scheme property on :root.
 	 */

--- a/theme.json
+++ b/theme.json
@@ -3,6 +3,25 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
+		"blocks": {
+			"core/button": {
+				"color": {
+					"gradients": true,
+					"customGradient": true
+				}
+			},
+			"core/group": {
+				"color": {
+					"gradients": true,
+					"customGradient": true
+				}
+			},
+			"core/paragraph": {
+				"color": {
+					"link": true
+				}
+			}
+		},
 		"color": {
 			"defaultPalette": false
 		},
@@ -71,7 +90,7 @@
 			]
 		},
 		"typography": {
-			"dropCap": false,
+			"dropCap": true,
 			"fluid": true,
 			"fontFamilies": [
 				{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Enabled gradients in the `theme.json` and added functionality into our existing `memberlite_filter_theme_json` where we build dynamic color palettes based on the active color scheme. The gradient color palette is also dynamic and uses colors in the active theme.

#### Example of gradients in the editor on the "Seaside Linen" color scheme:

<img width="495" height="341" alt="image" src="https://github.com/user-attachments/assets/adaa748a-573f-4c4e-99d1-1e4c610272a7" />

<img width="760" height="178" alt="image" src="https://github.com/user-attachments/assets/1cb1002d-f389-4491-9553-bb2068a3c4ba" />

#### Example of gradients when on the "Gotham" color scheme:

<img width="629" height="182" alt="image" src="https://github.com/user-attachments/assets/98605e03-2a52-4042-b582-1c4712289e8b" />

#### Example of gradient background on a group block using Cocoa Ash color scheme versus Evergreen

<img width="754" height="211" alt="image" src="https://github.com/user-attachments/assets/351499f4-5201-4458-847b-3fc766fa10cd" />

<img width="771" height="192" alt="image" src="https://github.com/user-attachments/assets/cfe5aa07-6caa-4711-8233-c228d30d63b4" />

[(Some of these gradients will pop more once the new action/accent colors have been merged in)](https://github.com/strangerstudios/memberlite/pull/327)

ℹ️ I also enabled the `dropCap` attribute and link colors for paragraph blocks in the `theme.json` file.

### How to test the changes in this Pull Request:

Confirm that you can see the gradient color palette in the block editor for `background` and that you can apply gradients to button and group blocks. Confirm that these colors change when the color scheme in **Appearance** > **Customize** > **Colors** is changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> New dynamic gradient color palette for button and group blocks, that change based on the active color scheme.
