### PR TITLE
Disable contentOnly mode on Memberlite patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -929,4 +929,4 @@ function memberlite_disable_content_only_for_unsynced_patterns( $settings ) {
 
 	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'memberlite_disable_content_only_for_unsynced_patterns' );
+add_filter( 'block_editor_settings_all', 'memberlite_disable_content_only_for_unsynced_patterns', 20, 1 );

--- a/functions.php
+++ b/functions.php
@@ -930,3 +930,4 @@ function memberlite_disable_content_only_for_unsynced_patterns( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'memberlite_disable_content_only_for_unsynced_patterns', 20, 1 );
+

--- a/functions.php
+++ b/functions.php
@@ -915,3 +915,18 @@ function memberlite_dedupe_editor_color_palette( $editor_settings, $context ) {
 	return $editor_settings;
 }
 add_filter( 'block_editor_settings_all', 'memberlite_dedupe_editor_color_palette', 20, 2 );
+
+/**
+ * Disable content only mode for unsynced patterns.
+ *
+ * @since TBD
+ *
+ * @param array $settings Block editor settings.
+ * @return array
+ */
+function memberlite_disable_content_only_for_unsynced_patterns( $settings ) {
+	$settings['disableContentOnlyForUnsyncedPatterns'] = true;
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'memberlite_disable_content_only_for_unsynced_patterns' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

[WordPress 7.0 changed the default behavior of unsynced patterns.](https://make.wordpress.org/core/2026/03/15/pattern-editing-in-wordpress-7-0/) Whenever they're inserted into the block editor, they default to `contentOnly` mode which only exposes the blocks necessary to edit content, like the paragraph, heading or button block. But if you want access to the structural blocks, like columns, spacers, grids etc. You have to click the "Edit Pattern" option. This is fine for sites where we're not expecting people to tinker with the block structure too much, but Memberlite encourages tinkering, encourages design, and having to constantly go in and out of an extra mode to design your blocks gets tedious over time.

The `disableContentOnlyForUnsyncedPatterns` setting is the recommended way to turn that now default feature off. It eliminates the need to "enter" a different layer of editing to make design changes/access structural blocks. Patterns dragged into the editor will expose all the blocks it contains, not just the content related ones.

**Before:**

<img width="861" height="405" alt="image" src="https://github.com/user-attachments/assets/dcce9450-1c80-4bd6-873b-5825f7efa9e9" />

**After:**

<img width="858" height="422" alt="image" src="https://github.com/user-attachments/assets/8d4e2715-c611-498f-b89c-09e6f3f4ebf3" />

ℹ️ **Note:** This change applies to all unsynced patterns, including ones that come bundled with WordPress core, not just Memberlite patterns.

### How to test the changes in this Pull Request:

1. Edit a post or page on your WP Admin.
2. Insert a pattern into the block editor, it can be a Memberlite pattern or a core pattern, doesn't matter. You can test with both just in case.
3. Click the "list view" icon on the top left so you can see the structure of the pattern. Confirm that you can see all the blocks that make up that pattern, not just content related blocks like heading, button, paragraph etc.
4. Confirm that you can click the pattern in the block editor, and there is no "Edit Pattern" option. You can edit everything from your block editor without going into an extra mode that isolates editing to that one pattern.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Disable WordPress 7.0's default `contentOnly` mode for unsynced patterns with the `disableContentOnlyForUnsyncedPatterns` and `block_editor_settings_all` filter.
