### PR TITLE
Update the header background image size recommendation to 1280x120

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -17,8 +17,8 @@ function memberlite_custom_header_setup() {
 		'memberlite_custom_header_args',
 		array(
 			'default-text-color' => '011935',
-			'height'             => 110,
-			'width'              => 1440,
+			'height'             => 120,
+			'width'              => 1280,
 			'flex-height'        => true,
 			'flex-height'        => true,
 			'wp-head-callback'   => 'memberlite_header_style',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a UX/copy only change in Customizer's "Header Image" panel where we previously recommended uploading a header image size that was 1440x10. After reviewing, we decided that 1280x120 produces better results. Documentation has already been updated.

<img width="296" height="354" alt="image" src="https://github.com/user-attachments/assets/e2fbba04-5b0f-4384-9a2b-28ddb0c3c31c" />

### How to test the changes in this Pull Request:

N/A

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update the recommended header image size to 1280x120 in Customizer's "Header Image" description.
