### PR TITLE
Remove figure element style where we set margin to 0

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -85,10 +85,6 @@ li > ol {
 	margin-top: var(--wp--preset--spacing--20);
 }
 
-figure {
-	margin: 0;
-}
-
 table {
 	background: var(--memberlite-color-site-background);
 	margin: var(--wp--preset--spacing--20) 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

https://github.com/strangerstudios/memberlite/blob/dev/src/scss/base/_base.scss#L88-L90

When we converted to Sass in 7.0, we updated our resets/base styles. We set the `figure` element to have `margin: 0;` but this overrides core styling and for any content using image blocks, can remove spacing that people previously expected. So we've removed this so core can do it's thing, and the figure element, which is only present in the image block (not present in the classic featured image function that spits out the image), can have the margin it's meant to.

### How to test the changes in this Pull Request:

Confirm that the `figure` element in the image block is no longer affected by our `_base.scss` (`main.css` after compiling) styles on the front-end. Keep in mind that any margins coming from the block editor settings for that block will override anything in our stylesheet.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove reset style that removed margin from the `figure` element that is used by the image block.
