### PR TITLE
Remove margin on .hentry when full/fluid/narrow width templates are applied

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -91,6 +91,11 @@
 		margin: 0;
 	}
 
+	/* Separate stacked entries when printing an archive; the screen gap is a vw clamp that wastes paper. */
+	.site-main > .hentry + .hentry {
+		margin-top: 24pt;
+	}
+
 	.masthead + .row,
 	.masthead-post-byline {
 		margin-top: 0;

--- a/src/scss/components/_grid-list.scss
+++ b/src/scss/components/_grid-list.scss
@@ -30,10 +30,6 @@
 		text-align: center;
 	}
 
-	.hentry {
-		margin: 0;
-	}
-
 	// Card titles
 	h1,
 	h2 {

--- a/src/scss/components/_shortcodes.scss
+++ b/src/scss/components/_shortcodes.scss
@@ -286,10 +286,6 @@ details {
 
 #widget_memberlite_recent_posts {
 
-	.post.hentry {
-		margin-bottom: 0;
-	}
-
 	// With thumbnail — grid layout
 	.widget_has_thumbnail .post.hentry .entry-header {
 		display: grid;
@@ -336,10 +332,6 @@ details {
 
 .page .entry-content .memberlite_subpagelist_item .entry-content {
 	border-bottom: none;
-}
-
-.columns .hentry.memberlite_subpagelist_item {
-	margin: 0;
 }
 
 #main .columns .hentry.memberlite_subpagelist_item .entry-content {

--- a/src/scss/pages/_page.scss
+++ b/src/scss/pages/_page.scss
@@ -42,10 +42,4 @@
 			width: auto;
 		}
 	}
-
-	// Assume that when a template is applied, we want to give edge to edge control for the entire page between the header/footer
-	// Margins can still be customized per block in the editor or child theme styles
-	.hentry {
-		margin-bottom: 0;
-	}
 }

--- a/src/scss/pages/_page.scss
+++ b/src/scss/pages/_page.scss
@@ -42,4 +42,10 @@
 			width: auto;
 		}
 	}
+
+	// Assume that when a template is applied, we want to give edge to edge control for the entire page between the header/footer
+	// Margins can still be customized per block in the editor or child theme styles
+	.hentry {
+		margin-bottom: 0;
+	}
 }

--- a/src/scss/structure/_content.scss
+++ b/src/scss/structure/_content.scss
@@ -13,7 +13,6 @@
 // -----------------------------------------------------------------------------
 
 .hentry {
-	margin: 0 0 var(--wp--preset--spacing--70);
 
 	// Entry banner (featured image as full-bleed header)
 	.entry-banner {
@@ -56,9 +55,9 @@
 	}
 }
 
-// Blank page template removes entry margin
-.page-template-blank .hentry {
-	margin: 0;
+// Space stacked entries in list-style loops. Grid layout uses the .grid-list gap.
+.site-main > .hentry + .hentry {
+	margin-top: var(--wp--preset--spacing--70);
 }
 
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/memberlite/blob/dev/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
