### PR TITLE
Fix header background image cropping and CSS sizing

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -17,10 +17,12 @@ function memberlite_custom_header_setup() {
 		'memberlite_custom_header_args',
 		array(
 			'default-text-color' => '011935',
-			'height'             => 110,
-			'width'              => 1440,
+			'height'             => 240,
+			'width'              => 1920,
 			'flex-height'        => true,
-			'flex-height'        => true,
+			'flex-width'         => true,
+			// Core caps flexible-width headers at 1500px unless 'max-width' raises it.
+			'max-width'          => 2560,
 			'wp-head-callback'   => 'memberlite_header_style',
 		)
 	);
@@ -49,9 +51,10 @@ if ( ! function_exists( 'memberlite_header_style' ) ) :
 			// Has a Custom Header been added?
 			if ( ! empty( $header_image ) ) { ?>
 			.site-header {
-				background-image: url(<?php header_image(); ?>);
-				background-repeat: repeat;
+				background-image: url("<?php header_image(); ?>");
+				background-repeat: no-repeat;
 				background-position: center center;
+				background-size: cover;
 			}
 		<?php }
 			// Has the text been hidden?

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -126,6 +126,13 @@ class Memberlite_Customize {
 			)
 		);
 
+		/* Header Image ---------------------------------- */
+		// Core's control text says the image is cropped "for a perfect fit"; it is scaled to cover instead.
+		$header_image_section = $wp_customize->get_section( 'header_image' );
+		if ( $header_image_section ) {
+			$header_image_section->description = __( 'Your header image is scaled to cover the header area and centered, so it does not need to match the suggested size exactly. A wide image around an 8:1 ratio works best &mdash; taller images are cropped at the top and bottom, and narrower ones are cropped at the sides.', 'memberlite' );
+		}
+
 		/* Footer ---------------------------------------- */
 		$wp_customize->add_section(
 			'memberlite_footer_options',


### PR DESCRIPTION
Fixes header background image cropping, the CSS that renders it, and the dimensions the Customizer suggests. Absorbs the goal of #334 — that PR aimed at the right problem, but the mechanism was the cause, not the recommendation.

## The crop bug

`inc/custom-header.php` listed `'flex-height' => true` twice. PHP silently discards the duplicate key, and the second one was almost certainly meant to be `'flex-width' => true`.

With `flex-width` off, core's `get_header_dimensions()` (`wp-admin/includes/class-custom-image-header.php`) falls through to `dst_width = $theme_width`, unconditionally. Cropping a header image resized it to exactly the `width` arg regardless of source resolution — a 3000px source came out as a 1440px file.

Since `.site-header` is full-bleed (only the inner `.row` is capped, at `71em`), the image stretches the whole viewport, so that ceiling sat below what wide and high-DPI displays need.

**Scope:** this only affected the crop path. Core offers "Skip Cropping, Publish Image as Is" whenever flex-height *or* flex-width is supported, and `flex-height` was already `true` — that path uses `_copy_image_file()` or the original file directly and never calls `wp_crop_image()`. So users who skipped cropping already kept their full-resolution original.

This enables `flex-width` and adds `max-width` to raise core's 1500px flexible-width cap. 2560 matches the `big_image_size_threshold` default (`wp-admin/includes/image.php:285`), which already bounds the source file, so it's the practical ceiling.

**One caveat:** `wp_crop_image()` ends in `$editor->save()`, which re-encodes at JPEG quality 82 regardless of dimensions. This PR addresses resampling loss, not compression artifacts. If a blurry header is mostly artifacts rather than upscaling, the lever is the `wp_editor_set_quality` filter — deliberately out of scope, since it has sitewide implications.

## The CSS bug

The inline style used `background-repeat: repeat` with no `background-size`, and there is no `background-size` for `.site-header` anywhere in the stylesheets.

- **Horizontally:** any viewport wider than the image tiled it, with a visible seam.
- **Vertically:** the header is content-sized, not fixed-height, so it commonly renders taller than the image and tiled downward too.

`background-position: center center` was also inert — with tiling there's nothing to letterbox, it just offsets the tile grid.

Switching to `no-repeat` + `background-size: cover` fixes both.

Also quotes the `url()` value: `header_image()` is `esc_url()`-escaped, but `esc_url()` doesn't encode parentheses, so a filename containing `(` breaks the declaration.

## The suggested dimensions

`1440 × 110` implied a 13:1 header. Measured in a browser against the theme, `.site-header` renders **212px tall** and holds that height across desktop viewports:

| viewport | header | aspect |
|---|---|---|
| 1920 | 1920 × 212 | 9.1:1 |
| 1600 | 1600 × 212 | 7.5:1 |
| 1440 | 1440 × 212 | 6.8:1 |
| 1280 | 1280 × 212 | 6.0:1 |
| 768 | 768 × 316 | 2.4:1 (nav stacks) |
| 480 | 480 × 89 | 5.4:1 (collapsed) |

So the real aspect is 6:1–9:1. Under `cover`, a suggestion much shorter than that forces heavy upscaling: a 1280 × 120 image in a 1440-wide header scales 1.77× to fill 212px of height, losing ~36% of its width off the sides and going soft in the process.

Changed to **1920 × 240** (8:1) — mid-range across desktop widths, with retina headroom under the 2560 cap.

*Measurement caveat:* taken on one site with no custom logo set, so 212px is the text-title path. A site with a tall logo may differ, and the numbers are only a suggestion now regardless — after this fix they drive the cropper's initial selection and the help text, not output resolution.

## The Customizer message

Core's header image control says:

> Your theme works best with an image with a header size of **1920 × 240** pixels — you'll be able to crop your image once you upload it for a perfect fit.

That string is a hardcoded `_e()`/`printf()` in `WP_Customize_Header_Image_Control::render_content()` (`wp-includes/customize/class-wp-customize-header-image-control.php:223-247`) with no filter, and "perfect fit" is now misleading — under `cover` any aspect works, it just crops.

Rather than subclass the control, this sets the `header_image` section description, which core leaves empty in the non-video case (`class-wp-customize-manager.php:5368`), to explain the cover behavior. Follows the existing `get_section( 'colors' )` pattern in `inc/customizer.php`.

## Testing

Browser-measured: the `.site-header` dimensions above.

Read from core, **not yet exercised**:

- Crop a header image larger than 1920px wide and confirm the stored file is no longer downscaled.
- Confirm the `max-width` path on a source over 2560px, where `big_image_size_threshold` also engages.
- View at a viewport wider than the image — no horizontal seam.
- Use a tall logo so the header exceeds the image height — no vertical repeat.
- Confirm the new section description renders in the Customizer.

The measurement run had no header image set, so the `cover` CSS itself has not been visually confirmed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
